### PR TITLE
Make custom UI with --path argument possible

### DIFF
--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,7 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
-		internal static string WebsiteDirectory;
+		internal static string WebsiteDirectory { get; private set; } = SharedInfo.DefaultWebsiteDirectory;
 
 		internal static HistoryTarget HistoryTarget { get; private set; }
 
@@ -62,9 +62,9 @@ namespace ArchiSteamFarm.IPC {
 			// The order of dependency injection matters, pay attention to it
 			IWebHostBuilder builder = new WebHostBuilder();
 
-			WebsiteDirectory = SharedInfo.CustomWebsiteDirectory;
-			if (!Directory.Exists(WebsiteDirectory)) {
-				WebsiteDirectory = SharedInfo.DefaultWebsiteDirectory;
+			string customDirectory = SharedInfo.CustomWebsiteDirectory;
+			if (!Directory.Exists(customDirectory)) {
+				WebsiteDirectory = customDirectory;
 			}
 
 			// Set default directories

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,21 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
-		private static string _WebsiteDirectory;
-		internal static string WebsiteDirectory {
-			get {
-				if (_WebsiteDirectory != null) {
-					return _WebsiteDirectory;
-				}
-
-				_WebsiteDirectory = SharedInfo.CustomWebsiteDirectory;
-				if (!Directory.Exists(_WebsiteDirectory)) {
-					_WebsiteDirectory = SharedInfo.DefaultWebsiteDirectory;
-				}
-
-				return _WebsiteDirectory;
-			}
-		}
+		internal static string WebsiteDirectory;
 
 		internal static HistoryTarget HistoryTarget { get; private set; }
 
@@ -75,6 +61,11 @@ namespace ArchiSteamFarm.IPC {
 
 			// The order of dependency injection matters, pay attention to it
 			IWebHostBuilder builder = new WebHostBuilder();
+
+			WebsiteDirectory = SharedInfo.CustomWebsiteDirectory;
+			if (!Directory.Exists(WebsiteDirectory)) {
+				WebsiteDirectory = SharedInfo.DefaultWebsiteDirectory;
+			}
 
 			// Set default directories
 			builder.UseContentRoot(SharedInfo.HomeDirectory);

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,7 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
-		internal static string WebsiteDirectory { get; private set; } = Path.Combine(SharedInfo.HomeDirectory, SharedInfo.WebsiteDirectory);
+		internal static string WebsiteDirectory { get; private set; } = SharedInfo.WebsiteDirectory;
 
 		internal static HistoryTarget HistoryTarget { get; private set; }
 

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,6 +34,22 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
+		private static string _WebsiteDirectory;
+		internal static string WebsiteDirectory {
+			get {
+				if (_WebsiteDirectory != null) {
+					return _WebsiteDirectory;
+				}
+
+				_WebsiteDirectory = SharedInfo.CustomWebsiteDirectory;
+				if (!Directory.Exists(_WebsiteDirectory)) {
+					_WebsiteDirectory = SharedInfo.DefaultWebsiteDirectory;
+				}
+
+				return _WebsiteDirectory;
+			}
+		}
+
 		internal static HistoryTarget HistoryTarget { get; private set; }
 
 		private static IWebHost KestrelWebHost;
@@ -62,7 +78,7 @@ namespace ArchiSteamFarm.IPC {
 
 			// Set default directories
 			builder.UseContentRoot(SharedInfo.HomeDirectory);
-			builder.UseWebRoot(SharedInfo.WebsiteDirectory);
+			builder.UseWebRoot(WebsiteDirectory);
 
 			// Check if custom config is available
 			string absoluteConfigDirectory = Path.Combine(Directory.GetCurrentDirectory(), SharedInfo.ConfigDirectory);

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -63,7 +63,7 @@ namespace ArchiSteamFarm.IPC {
 			IWebHostBuilder builder = new WebHostBuilder();
 
 			string customDirectory = SharedInfo.CustomWebsiteDirectory;
-			if (!Directory.Exists(customDirectory)) {
+			if (Directory.Exists(customDirectory)) {
 				WebsiteDirectory = customDirectory;
 			}
 

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,8 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
-		// We can use a relative path to the location of ASFs executable as WebRoot to serve default ASF-ui because Kestrel uses it relative to the path given as ContentRoot and not relative to Directory.GetCurrentDirectory()
-		internal static string WebsiteDirectory { get; private set; } = SharedInfo.WebsiteDirectory;
+		internal static string WebsiteDirectory { get; private set; } = Path.Combine(SharedInfo.HomeDirectory, SharedInfo.WebsiteDirectory);
 
 		internal static HistoryTarget HistoryTarget { get; private set; }
 

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,6 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
+		// We can use a relative path to the location of ASFs executable as WebRoot to serve default ASF-ui because Kestrel uses it relative to the path given as ContentRoot and not relative to Directory.GetCurrentDirectory()
 		internal static string WebsiteDirectory { get; private set; } = SharedInfo.WebsiteDirectory;
 
 		internal static HistoryTarget HistoryTarget { get; private set; }

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -34,7 +34,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		private const string ConfigurationFile = nameof(IPC) + ".config";
 
-		internal static string WebsiteDirectory { get; private set; } = SharedInfo.DefaultWebsiteDirectory;
+		internal static string WebsiteDirectory { get; private set; } = Path.Combine(SharedInfo.HomeDirectory, SharedInfo.WebsiteDirectory);
 
 		internal static HistoryTarget HistoryTarget { get; private set; }
 
@@ -62,7 +62,7 @@ namespace ArchiSteamFarm.IPC {
 			// The order of dependency injection matters, pay attention to it
 			IWebHostBuilder builder = new WebHostBuilder();
 
-			string customDirectory = SharedInfo.CustomWebsiteDirectory;
+			string customDirectory = Path.Combine(Directory.GetCurrentDirectory(), SharedInfo.WebsiteDirectory);
 			if (Directory.Exists(customDirectory)) {
 				WebsiteDirectory = customDirectory;
 			}

--- a/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
@@ -48,9 +48,6 @@ namespace ArchiSteamFarm.IPC.Controllers.Api {
 			}
 
 			string directoryPath = Path.Combine(ArchiKestrel.WebsiteDirectory, directory);
-			if (ArchiKestrel.WebsiteDirectory == SharedInfo.WebsiteDirectory) {
-				directoryPath = Path.Combine(SharedInfo.HomeDirectory, directoryPath);
-			}
 			if (!Directory.Exists(directoryPath)) {
 				return BadRequest(new GenericResponse<HashSet<string>>(false, string.Format(Strings.ErrorIsInvalid, directory)));
 			}

--- a/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
@@ -47,7 +47,7 @@ namespace ArchiSteamFarm.IPC.Controllers.Api {
 				return BadRequest(new GenericResponse<HashSet<string>>(false, string.Format(Strings.ErrorIsEmpty, nameof(directory))));
 			}
 
-			string directoryPath = Path.Combine(SharedInfo.HomeDirectory, SharedInfo.WebsiteDirectory, directory);
+			string directoryPath = Path.Combine(ArchiKestrel.WebsiteDirectory, directory);
 			if (!Directory.Exists(directoryPath)) {
 				return BadRequest(new GenericResponse<HashSet<string>>(false, string.Format(Strings.ErrorIsInvalid, directory)));
 			}

--- a/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/WWWController.cs
@@ -48,6 +48,9 @@ namespace ArchiSteamFarm.IPC.Controllers.Api {
 			}
 
 			string directoryPath = Path.Combine(ArchiKestrel.WebsiteDirectory, directory);
+			if (ArchiKestrel.WebsiteDirectory == SharedInfo.WebsiteDirectory) {
+				directoryPath = Path.Combine(SharedInfo.HomeDirectory, directoryPath);
+			}
 			if (!Directory.Exists(directoryPath)) {
 				return BadRequest(new GenericResponse<HashSet<string>>(false, string.Format(Strings.ErrorIsInvalid, directory)));
 			}

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -49,12 +49,25 @@ namespace ArchiSteamFarm {
 		internal const string StatisticsServer = "asf.justarchi.net";
 		internal const string UlongCompatibilityStringPrefix = "s_";
 		internal const string UpdateDirectory = "_old";
-		internal const string WebsiteDirectory = "www";
 
 		internal static string HomeDirectory => Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 		internal static Guid ModuleVersion => Assembly.GetEntryAssembly().ManifestModule.ModuleVersionId;
 		internal static string PublicIdentifier => AssemblyName + (BuildInfo.IsCustomBuild ? "-custom" : "");
 		internal static Version Version => Assembly.GetEntryAssembly().GetName().Version;
+		internal static string WebsiteDirectory {
+			get {
+				if (_WebsiteDirectory != null) {
+					return _WebsiteDirectory;
+				}
+
+				string customDirectory = CustomWebsiteDirectory;
+				return _WebsiteDirectory = Directory.Exists(customDirectory) ? customDirectory : DefaultWebsiteDirectory;
+			}
+		}
+
+		private static string _WebsiteDirectory;
+		private static string CustomWebsiteDirectory => Path.Combine(Directory.GetCurrentDirectory(), "www");
+		private static string DefaultWebsiteDirectory => Path.Combine(HomeDirectory, "www");
 
 		[SuppressMessage("ReSharper", "ConvertToConstant.Global")]
 		internal static class BuildInfo {

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -54,20 +54,8 @@ namespace ArchiSteamFarm {
 		internal static Guid ModuleVersion => Assembly.GetEntryAssembly().ManifestModule.ModuleVersionId;
 		internal static string PublicIdentifier => AssemblyName + (BuildInfo.IsCustomBuild ? "-custom" : "");
 		internal static Version Version => Assembly.GetEntryAssembly().GetName().Version;
-		internal static string WebsiteDirectory {
-			get {
-				if (_WebsiteDirectory != null) {
-					return _WebsiteDirectory;
-				}
-
-				string customDirectory = CustomWebsiteDirectory;
-				return _WebsiteDirectory = Directory.Exists(customDirectory) ? customDirectory : DefaultWebsiteDirectory;
-			}
-		}
-
-		private static string _WebsiteDirectory;
-		private static string CustomWebsiteDirectory => Path.Combine(Directory.GetCurrentDirectory(), "www");
-		private static string DefaultWebsiteDirectory => Path.Combine(HomeDirectory, "www");
+		internal static string CustomWebsiteDirectory => Path.Combine(Directory.GetCurrentDirectory(), "www");
+		internal static string DefaultWebsiteDirectory => Path.Combine(HomeDirectory, "www");
 
 		[SuppressMessage("ReSharper", "ConvertToConstant.Global")]
 		internal static class BuildInfo {

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -49,13 +49,12 @@ namespace ArchiSteamFarm {
 		internal const string StatisticsServer = "asf.justarchi.net";
 		internal const string UlongCompatibilityStringPrefix = "s_";
 		internal const string UpdateDirectory = "_old";
+		internal const string WebsiteDirectory = "www";
 
 		internal static string HomeDirectory => Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 		internal static Guid ModuleVersion => Assembly.GetEntryAssembly().ManifestModule.ModuleVersionId;
 		internal static string PublicIdentifier => AssemblyName + (BuildInfo.IsCustomBuild ? "-custom" : "");
 		internal static Version Version => Assembly.GetEntryAssembly().GetName().Version;
-		internal static string CustomWebsiteDirectory => Path.Combine(Directory.GetCurrentDirectory(), "www");
-		internal static string DefaultWebsiteDirectory => Path.Combine(HomeDirectory, "www");
 
 		[SuppressMessage("ReSharper", "ConvertToConstant.Global")]
 		internal static class BuildInfo {


### PR DESCRIPTION
As of this PR if the user has a custom path set with --path and there exists a directory called www within that folder this www-folder will be used as root directory for all non-Api requests on IPC allowing users to use whatever GUI they want