### PR TITLE
Add CORS

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.8.9" />
     <PackageReference Include="Humanizer" Version="2.5.1" />
     <PackageReference Include="Markdig.Signed" Version="0.15.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0-preview3-35497" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0-preview3-35497" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0-preview3-35497" />

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.8.9" />
     <PackageReference Include="Humanizer" Version="2.5.1" />
     <PackageReference Include="Markdig.Signed" Version="0.15.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0-preview3-35497" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0-preview3-35497" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0-preview3-35497" />
     <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0-preview3-35497" />

--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -58,6 +58,10 @@ namespace ArchiSteamFarm.IPC {
 			if (!string.IsNullOrEmpty(Program.GlobalConfig.IPCPassword)) {
 				// We need ApiAuthenticationMiddleware for IPCPassword
 				app.UseWhen(context => context.Request.Path.StartsWithSegments("/Api", StringComparison.OrdinalIgnoreCase), appBuilder => appBuilder.UseMiddleware<ApiAuthenticationMiddleware>());
+
+				// We need CORS to allow for Userscripts and other integrations outside of Kestrel and it's respectable folders (ArchiKestre.WebsiteDirectory)
+				// We add it here so that users need to confirm their password in their third party app
+				app.UseCors();
 			}
 
 			// We need WebSockets support for /Api/Log
@@ -90,6 +94,17 @@ namespace ArchiSteamFarm.IPC {
 
 			// Add support for response compression
 			services.AddResponseCompression();
+
+			// Add CORS to allow Userscripts and third party apps
+			services.AddCors(
+				builder => {
+					builder.AddDefaultPolicy(
+						policyBuilder => {
+							policyBuilder.AllowAnyOrigin();
+						}
+					);
+				}
+			);
 
 			// Add swagger documentation generation
 			services.AddSwaggerGen(

--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -59,7 +59,7 @@ namespace ArchiSteamFarm.IPC {
 				// We need ApiAuthenticationMiddleware for IPCPassword
 				app.UseWhen(context => context.Request.Path.StartsWithSegments("/Api", StringComparison.OrdinalIgnoreCase), appBuilder => appBuilder.UseMiddleware<ApiAuthenticationMiddleware>());
 
-				// We want to apply CORS policy in order to allow userscripts and other third-party integrations to co9mmunicate with ASF API
+				// We want to apply CORS policy in order to allow userscripts and other third-party integrations to communicate with ASF API
 				// We apply CORS policy only with IPCPassword set as extra authentication measure
 				app.UseCors();
 			}

--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -59,8 +59,8 @@ namespace ArchiSteamFarm.IPC {
 				// We need ApiAuthenticationMiddleware for IPCPassword
 				app.UseWhen(context => context.Request.Path.StartsWithSegments("/Api", StringComparison.OrdinalIgnoreCase), appBuilder => appBuilder.UseMiddleware<ApiAuthenticationMiddleware>());
 
-				// We need CORS to allow for Userscripts and other integrations outside of Kestrel and it's respectable folders (ArchiKestre.WebsiteDirectory)
-				// We add it here so that users need to confirm their password in their third party app
+				// We want to apply CORS policy in order to allow userscripts and other third-party integrations to co9mmunicate with ASF API
+				// We apply CORS policy only with IPCPassword set as extra authentication measure
 				app.UseCors();
 			}
 
@@ -95,7 +95,7 @@ namespace ArchiSteamFarm.IPC {
 			// Add support for response compression
 			services.AddResponseCompression();
 
-			// Add CORS to allow Userscripts and third party apps
+			// Add CORS to allow userscripts and third-party apps
 			services.AddCors(
 				builder => {
 					builder.AddDefaultPolicy(


### PR DESCRIPTION
Enable CORS for users that have IPCPassword set. This allows for custom Userscripts and other third party apps.