### PR TITLE
ContextID follow-up fix

### DIFF
--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -756,7 +756,7 @@ namespace ArchiSteamFarm {
 				return FormatStaticResponse(string.Format(Strings.ErrorIsInvalid, nameof(appID)));
 			}
 
-			if (!byte.TryParse(targetContextID, out byte contextID) || (contextID == 0)) {
+			if (!uint.TryParse(targetContextID, out uint contextID) || (contextID == 0)) {
 				return FormatStaticResponse(string.Format(Strings.ErrorIsInvalid, nameof(contextID)));
 			}
 


### PR DESCRIPTION
This line went unnoticed in PR #990, affecting the `!transfer^` command.