### PR TITLE
Add x64 Dockerfiles based on alpine

### DIFF
--- a/Dockerfile.Service.x64.alpine
+++ b/Dockerfile.Service.x64.alpine
@@ -1,0 +1,29 @@
+FROM node:lts-alpine AS build-node
+WORKDIR /app
+COPY ASF-ui .
+RUN echo "node: $(node --version)" && \
+  echo "npm: $(npm --version)" && \
+  npm ci && \
+  npm run-script deploy
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build-dotnet
+ENV CONFIGURATION Release
+ENV NET_CORE_VERSION netcoreapp2.2
+WORKDIR /app
+COPY --from=build-node /app/dist ASF-ui/dist
+COPY ArchiSteamFarm ArchiSteamFarm
+COPY ArchiSteamFarm.Tests ArchiSteamFarm.Tests
+RUN dotnet --info && \
+  dotnet build ArchiSteamFarm -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/source' /nologo && \
+  dotnet test ArchiSteamFarm.Tests -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/source' /nologo && \
+  dotnet publish ArchiSteamFarm -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/publish' /nologo /p:ASFVariant=generic /p:LinkDuringPublish=false && \
+  cp "ArchiSteamFarm/overlay/generic/ArchiSteamFarm-Service.sh" "ArchiSteamFarm/out/publish/ArchiSteamFarm-Service.sh"
+
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2-alpine-slim AS runtime
+ENV ASPNETCORE_URLS=
+LABEL maintainer="JustArchi <JustArchi@JustArchi.net>"
+EXPOSE 1242
+WORKDIR /app
+RUN apk add --no-cache --no-progress bash
+COPY --from=build-dotnet /app/ArchiSteamFarm/out/publish .
+ENTRYPOINT ["./ArchiSteamFarm-Service.sh", "--no-restart", "--process-required", "--system-required"]

--- a/Dockerfile.x64.alpine
+++ b/Dockerfile.x64.alpine
@@ -1,0 +1,29 @@
+FROM node:lts-alpine AS build-node
+WORKDIR /app
+COPY ASF-ui .
+RUN echo "node: $(node --version)" && \
+  echo "npm: $(npm --version)" && \
+  npm ci -s && \
+  npm run-script deploy -s
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build-dotnet
+ENV CONFIGURATION Release
+ENV NET_CORE_VERSION netcoreapp2.2
+WORKDIR /app
+COPY --from=build-node /app/dist ASF-ui/dist
+COPY ArchiSteamFarm ArchiSteamFarm
+COPY ArchiSteamFarm.Tests ArchiSteamFarm.Tests
+RUN dotnet --info && \
+  dotnet build ArchiSteamFarm -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/source' /nologo && \
+  dotnet test ArchiSteamFarm.Tests -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/source' /nologo && \
+  dotnet publish ArchiSteamFarm -c "$CONFIGURATION" -f "$NET_CORE_VERSION" -o 'out/publish' /nologo /p:ASFVariant=docker /p:LinkDuringPublish=false && \
+  cp "ArchiSteamFarm/overlay/generic/ArchiSteamFarm.sh" "ArchiSteamFarm/out/publish/ArchiSteamFarm.sh"
+
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2-alpine AS runtime
+ENV ASPNETCORE_URLS=
+LABEL maintainer="JustArchi <JustArchi@JustArchi.net>"
+EXPOSE 1242
+WORKDIR /app
+RUN apk add --no-cache --no-progress bash
+COPY --from=build-dotnet /app/ArchiSteamFarm/out/publish .
+ENTRYPOINT ["./ArchiSteamFarm.sh", "--no-restart", "--process-required", "--system-required"]


### PR DESCRIPTION
Main advantage of alpine is that the resulting image is almost half as big (201 MB vs 113 MB).
![](https://i.imgur.com/33DyiRP.png)

I did a quick test with my bots and works like a charm.
There is sadly no alpine variant of dotnet for the arm architecture.
