### PR TITLE
Split steam messages with respect to newlines

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1180,7 +1180,7 @@ namespace ArchiSteamFarm {
 				bool copyNewline = false;
 
 				if (message.Length - i > maxMessageLength) {
-					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
+					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength - Environment.NewLine.Length, maxMessageLength - Environment.NewLine.Length, StringComparison.Ordinal);
 
 					if (lastNewLine > i) {
 						partLength = lastNewLine - i + Environment.NewLine.Length;
@@ -1269,7 +1269,7 @@ namespace ArchiSteamFarm {
 				bool copyNewline = false;
 
 				if (message.Length - i > maxMessageLength) {
-					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
+					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength - Environment.NewLine.Length, maxMessageLength - Environment.NewLine.Length, StringComparison.Ordinal);
 
 					if (lastNewLine > i) {
 						partLength = lastNewLine - i + Environment.NewLine.Length;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1174,15 +1174,11 @@ namespace ArchiSteamFarm {
 			message = Escape(message);
 
 			int i = 0;
-			int partLength;
 			while (i < message.Length) {
+				int partLength;
 				if (message.Length - i > maxMessageLength) {
-					int lastNewLine = message.LastIndexOf('\n', i+maxMessageLength, maxMessageLength);
-					if (lastNewLine > 0 && lastNewLine > i) {
-						partLength = lastNewLine-i; //split at last newline
-					} else {
-						partLength = maxMessageLength; //if there is no new lines - fallback to default
-					}
+					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength);
+					partLength = lastNewLine > i ? lastNewLine - i : maxMessageLength;
 				} else {
 					partLength = message.Length - i; //less than maxMessageLength left
 				}
@@ -1232,6 +1228,7 @@ namespace ArchiSteamFarm {
 				} finally {
 					MessagingSemaphore.Release();
 				}
+
 				i += partLength;
 			}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1174,13 +1174,15 @@ namespace ArchiSteamFarm {
 			message = Escape(message);
 
 			int i = 0;
+
 			while (i < message.Length) {
 				int partLength;
+
 				if (message.Length - i > maxMessageLength) {
-					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength);
+					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
 					partLength = lastNewLine > i ? lastNewLine - i : maxMessageLength;
 				} else {
-					partLength = message.Length - i; //less than maxMessageLength left
+					partLength = message.Length - i;
 				}
 
 				string messagePart = message.Substring(i, partLength);
@@ -1253,8 +1255,19 @@ namespace ArchiSteamFarm {
 			// We must escape our message prior to sending it
 			message = Escape(message);
 
-			for (int i = 0; i < message.Length; i += maxMessageLength) {
-				string messagePart = message.Substring(i, Math.Min(maxMessageLength, message.Length - i));
+			int i = 0;
+
+			while (i < message.Length) {
+				int partLength;
+
+				if (message.Length - i > maxMessageLength) {
+					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
+					partLength = lastNewLine > i ? lastNewLine - i : maxMessageLength;
+				} else {
+					partLength = message.Length - i;
+				}
+
+				string messagePart = message.Substring(i, partLength);
 
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
 				if ((messagePart.Length >= maxMessageLength) && (messagePart[messagePart.Length - 1] == '\\') && (messagePart[messagePart.Length - 2] != '\\')) {
@@ -1299,6 +1312,8 @@ namespace ArchiSteamFarm {
 				} finally {
 					MessagingSemaphore.Release();
 				}
+
+				i += partLength;
 			}
 
 			return true;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1173,8 +1173,21 @@ namespace ArchiSteamFarm {
 			// We must escape our message prior to sending it
 			message = Escape(message);
 
-			for (int i = 0; i < message.Length; i += maxMessageLength) {
-				string messagePart = message.Substring(i, Math.Min(maxMessageLength, message.Length - i));
+			int i = 0;
+			int partLength;
+			while (i < message.Length) {
+				if (message.Length - i > maxMessageLength) {
+					int lastNewLine = message.LastIndexOf('\n', i+maxMessageLength, maxMessageLength);
+					if (lastNewLine > 0 && lastNewLine > i) {
+						partLength = lastNewLine-i; //split at last newline
+					} else {
+						partLength = maxMessageLength; //if there is no new lines - fallback to default
+					}
+				} else {
+					partLength = message.Length - i; //less than maxMessageLength left
+				}
+
+				string messagePart = message.Substring(i, partLength);
 
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
 				if ((messagePart.Length >= maxMessageLength) && (messagePart[messagePart.Length - 1] == '\\') && (messagePart[messagePart.Length - 2] != '\\')) {
@@ -1219,6 +1232,7 @@ namespace ArchiSteamFarm {
 				} finally {
 					MessagingSemaphore.Release();
 				}
+				i += partLength;
 			}
 
 			return true;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1185,14 +1185,13 @@ namespace ArchiSteamFarm {
 					partLength = message.Length - i;
 				}
 
-				string messagePart = message.Substring(i, partLength);
-
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
-				if ((messagePart.Length >= maxMessageLength) && (messagePart[messagePart.Length - 1] == '\\') && (messagePart[messagePart.Length - 2] != '\\')) {
+				if ((partLength == maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
 					// Instead, we'll cut this message one char short and include the rest in next iteration
-					messagePart = messagePart.Remove(messagePart.Length - 1);
-					i--;
+					partLength--;
 				}
+
+				string messagePart = message.Substring(i, partLength);
 
 				messagePart = ASF.GlobalConfig.SteamMessagePrefix + (i > 0 ? "…" : "") + messagePart + (maxMessageLength < message.Length - i ? "…" : "");
 
@@ -1267,14 +1266,13 @@ namespace ArchiSteamFarm {
 					partLength = message.Length - i;
 				}
 
-				string messagePart = message.Substring(i, partLength);
-
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
-				if ((messagePart.Length >= maxMessageLength) && (messagePart[messagePart.Length - 1] == '\\') && (messagePart[messagePart.Length - 2] != '\\')) {
+				if ((partLength == maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
 					// Instead, we'll cut this message one char short and include the rest in next iteration
-					messagePart = messagePart.Remove(messagePart.Length - 1);
-					i--;
+					partLength--;
 				}
+
+				string messagePart = message.Substring(i, partLength);
 
 				messagePart = ASF.GlobalConfig.SteamMessagePrefix + (i > 0 ? "…" : "") + messagePart + (maxMessageLength < message.Length - i ? "…" : "");
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1177,10 +1177,18 @@ namespace ArchiSteamFarm {
 
 			while (i < message.Length) {
 				int partLength;
+				bool copyNewline = false;
 
 				if (message.Length - i > maxMessageLength) {
 					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
-					partLength = lastNewLine > i ? lastNewLine - i : maxMessageLength;
+
+					if (lastNewLine > i) {
+						partLength = lastNewLine - i + Environment.NewLine.Length;
+						copyNewline = true;
+					} else {
+						partLength = maxMessageLength;
+					}
+
 				} else {
 					partLength = message.Length - i;
 				}
@@ -1230,7 +1238,7 @@ namespace ArchiSteamFarm {
 					MessagingSemaphore.Release();
 				}
 
-				i += partLength;
+				i += partLength - (copyNewline ? Environment.NewLine.Length : 0);
 			}
 
 			return true;
@@ -1258,10 +1266,18 @@ namespace ArchiSteamFarm {
 
 			while (i < message.Length) {
 				int partLength;
+				bool copyNewline = false;
 
 				if (message.Length - i > maxMessageLength) {
 					int lastNewLine = message.LastIndexOf(Environment.NewLine, i + maxMessageLength, maxMessageLength, StringComparison.Ordinal);
-					partLength = lastNewLine > i ? lastNewLine - i : maxMessageLength;
+
+					if (lastNewLine > i) {
+						partLength = lastNewLine - i + Environment.NewLine.Length;
+						copyNewline = true;
+					} else {
+						partLength = maxMessageLength;
+					}
+
 				} else {
 					partLength = message.Length - i;
 				}
@@ -1311,7 +1327,7 @@ namespace ArchiSteamFarm {
 					MessagingSemaphore.Release();
 				}
 
-				i += partLength;
+				i += partLength - (copyNewline ? Environment.NewLine.Length : 0);
 			}
 
 			return true;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1186,7 +1186,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
-				if ((partLength == maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
+				if ((partLength >= maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
 					// Instead, we'll cut this message one char short and include the rest in next iteration
 					partLength--;
 				}
@@ -1267,7 +1267,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// If our message is of max length and ends with a single '\' then we can't split it here, it escapes the next character
-				if ((partLength == maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
+				if ((partLength >= maxMessageLength) && (message[i + partLength - 1] == '\\') && (message[i + partLength - 2] != '\\')) {
 					// Instead, we'll cut this message one char short and include the rest in next iteration
 					partLength--;
 				}


### PR DESCRIPTION
If steam chat message is too long tries to split it by newline closest to character limit. If that's impossible - falls back to current behavior.