### PR TITLE
Fix wallet code redeeming due to Steam changes

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2793,6 +2793,8 @@ namespace ArchiSteamFarm {
 
 				ArchiLogger.LogGenericInfo(Strings.Starting);
 
+				bool assumeWalletKeyOnBadActivationCode = BotConfig.RedeemingPreferences.HasFlag(BotConfig.ERedeemingPreferences.AssumeWalletKeyOnBadActivationCode);
+
 				while (IsConnectedAndLoggedOn && BotDatabase.HasGamesToRedeemInBackground) {
 					(string key, string name) = BotDatabase.GetGameToRedeemInBackground();
 
@@ -2808,7 +2810,7 @@ namespace ArchiSteamFarm {
 						continue;
 					}
 
-					if ((result.PurchaseResultDetail == EPurchaseResultDetail.CannotRedeemCodeFromClient) && (WalletCurrency != ECurrencyCode.Invalid)) {
+					if (((result.PurchaseResultDetail == EPurchaseResultDetail.CannotRedeemCodeFromClient) || ((result.PurchaseResultDetail == EPurchaseResultDetail.BadActivationCode) && assumeWalletKeyOnBadActivationCode)) && (WalletCurrency != ECurrencyCode.Invalid)) {
 						// If it's a wallet code, we try to redeem it first, then handle the inner result as our primary one
 						(EResult Result, EPurchaseResultDetail? PurchaseResult)? walletResult = await ArchiWebHandler.RedeemWalletKey(key).ConfigureAwait(false);
 

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -427,7 +427,8 @@ namespace ArchiSteamFarm {
 			Forwarding = 1,
 			Distributing = 2,
 			KeepMissingGames = 4,
-			All = Forwarding | Distributing | KeepMissingGames
+			AssumeWalletKeyOnBadActivationCode = 8,
+			All = Forwarding | Distributing | KeepMissingGames | AssumeWalletKeyOnBadActivationCode
 		}
 
 		[Flags]

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2196,7 +2196,8 @@ namespace ArchiSteamFarm {
 									// Either bot will be changed, or loop aborted
 									currentBot = null;
 								} else {
-									if ((result.PurchaseResultDetail == EPurchaseResultDetail.CannotRedeemCodeFromClient) && (Bot.WalletCurrency != ECurrencyCode.Invalid)) {
+									if ((result.PurchaseResultDetail == EPurchaseResultDetail.BadActivationCode) && (Bot.WalletCurrency != ECurrencyCode.Invalid)) {
+										// We may try to assume that key is a wallet code, because Steam gives BadActivationCode in this case
 										// If it's a wallet code, we try to redeem it first, then handle the inner result as our primary one
 										(EResult Result, EPurchaseResultDetail? PurchaseResult)? walletResult = await currentBot.ArchiWebHandler.RedeemWalletKey(key).ConfigureAwait(false);
 

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2196,8 +2196,7 @@ namespace ArchiSteamFarm {
 									// Either bot will be changed, or loop aborted
 									currentBot = null;
 								} else {
-									if ((result.PurchaseResultDetail == EPurchaseResultDetail.BadActivationCode) && (Bot.WalletCurrency != ECurrencyCode.Invalid)) {
-										// We may try to assume that key is a wallet code, because Steam gives BadActivationCode in this case
+									if ((result.PurchaseResultDetail == EPurchaseResultDetail.CannotRedeemCodeFromClient) && (Bot.WalletCurrency != ECurrencyCode.Invalid)) {
 										// If it's a wallet code, we try to redeem it first, then handle the inner result as our primary one
 										(EResult Result, EPurchaseResultDetail? PurchaseResult)? walletResult = await currentBot.ArchiWebHandler.RedeemWalletKey(key).ConfigureAwait(false);
 


### PR DESCRIPTION
Steam has changed result for wallet code redeeming in client from CannotRedeemCodeFromClient to BadActivationCode, this fixes the check