### PR TITLE
Add Fair trades to MatchActively

### DIFF
--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -70,6 +70,8 @@ namespace ArchiSteamFarm.Json {
 			[PublicAPI]
 			public EType Type { get; internal set; }
 
+			internal Asset CreateShallowCopy() => (Asset) MemberwiseClone();
+
 #pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "amount", Required = Required.Always)]
 			[NotNull]

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -491,10 +491,10 @@ namespace ArchiSteamFarm {
 										HashSet<Steam.Asset> fairItemsToReceive = Trading.GetTradableItemsFromInventory(theirInventory, fairClassIDsToReceive);
 
 										// Filter inventory for the sets we're looking for for IsTradeNeutralOrBetter
-										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>(theirInventory);
+										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>();
 
-										foreach (Steam.Asset item in fairFiltered.Where(item => item.RealAppID != set.RealAppID)) {
-											fairFiltered.Remove(item);
+										foreach (Steam.Asset item in theirInventory.Where(item => item.RealAppID == set.RealAppID)) {
+											fairFiltered.Add(item.CreateShallowCopy());
 										}
 
 										// Actual check:
@@ -585,15 +585,6 @@ namespace ArchiSteamFarm {
 					HashSet<Steam.Asset> itemsToReceive = Trading.GetTradableItemsFromInventory(theirInventory, classIDsToReceive);
 
 					if ((itemsToGive.Count != itemsToReceive.Count) || !Trading.IsFairExchange(itemsToGive, itemsToReceive)) {
-						// Failsafe
-						Bot.ArchiLogger.LogGenericError(string.Format(Strings.WarningFailedWithError, Strings.ErrorAborted));
-
-						return false;
-					}
-
-					HashSet<Steam.Asset> fairTheirInventory = new HashSet<Steam.Asset>(theirInventory);
-
-					if (!listedUser.MatchEverything && !Trading.IsTradeNeutralOrBetter(fairTheirInventory, itemsToReceive, itemsToGive)) {
 						// Failsafe
 						Bot.ArchiLogger.LogGenericError(string.Format(Strings.WarningFailedWithError, Strings.ErrorAborted));
 

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -493,7 +493,7 @@ namespace ArchiSteamFarm {
 										// Filter inventory for the sets we're looking for for IsTradeNeutralOrBetter
 										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>();
 
-										foreach (Steam.Asset item in theirInventory.Where(item => item.RealAppID == set.RealAppID)) {
+										foreach (Steam.Asset item in theirInventory.Where(item => (item.RealAppID == set.RealAppID) && (item.Type == set.Type) && (item.Rarity == set.Rarity))) {
 											fairFiltered.Add(item.CreateShallowCopy());
 										}
 

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -377,7 +377,7 @@ namespace ArchiSteamFarm {
 			byte emptyMatches = 0;
 			HashSet<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> skippedSetsThisRound = new HashSet<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)>();
 
-			foreach (ListedUser listedUser in listedUsers.Where(listedUser => acceptedMatchableTypes.Any(listedUser.MatchableTypes.Contains) && (!triedSteamIDs.TryGetValue(listedUser.SteamID, out (byte Tries, ISet<ulong> GivenAssetIDs, ISet<ulong> ReceivedAssetIDs) attempt) || (attempt.Tries < byte.MaxValue)) && !Bot.IsBlacklistedFromTrades(listedUser.SteamID)).OrderByDescending(listedUser => listedUser.MatchEverything).ThenBy(listedUser => triedSteamIDs.TryGetValue(listedUser.SteamID, out (byte Tries, ISet<ulong> GivenAssetIDs, ISet<ulong> ReceivedAssetIDs) attempt) ? attempt.Tries : 0).ThenByDescending(listedUser => listedUser.Score).Take(MaxMatchedBotsHard)) {
+			foreach (ListedUser listedUser in listedUsers.Where(listedUser => acceptedMatchableTypes.Any(listedUser.MatchableTypes.Contains) && (!triedSteamIDs.TryGetValue(listedUser.SteamID, out (byte Tries, ISet<ulong> GivenAssetIDs, ISet<ulong> ReceivedAssetIDs) attempt) || (attempt.Tries < byte.MaxValue)) && !Bot.IsBlacklistedFromTrades(listedUser.SteamID)).OrderBy(listedUser => triedSteamIDs.TryGetValue(listedUser.SteamID, out (byte Tries, ISet<ulong> GivenAssetIDs, ISet<ulong> ReceivedAssetIDs) attempt) ? attempt.Tries : 0).ThenByDescending(listedUser => listedUser.MatchEverything).ThenByDescending(listedUser => listedUser.Score).Take(MaxMatchedBotsHard)) {
 				HashSet<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> wantedSets = ourTradableState.Keys.Where(set => !skippedSetsThisRound.Contains(set) && listedUser.MatchableTypes.Contains(set.Type)).ToHashSet();
 
 				if (wantedSets.Count == 0) {
@@ -491,10 +491,10 @@ namespace ArchiSteamFarm {
 										HashSet<Steam.Asset> fairItemsToReceive = Trading.GetTradableItemsFromInventory(theirInventory, fairClassIDsToReceive);
 
 										// Filter inventory for the sets we're looking for for IsTradeNeutralOrBetter
-										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>();
+										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>(theirInventory);
 
-										foreach (Steam.Asset item in theirInventory.Where(item => item.RealAppID == set.RealAppID)) {
-											fairFiltered.Add(item);
+										foreach (Steam.Asset item in fairFiltered.Where(item => item.RealAppID != set.RealAppID)) {
+											fairFiltered.Remove(item);
 										}
 
 										// Actual check:

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -558,8 +558,8 @@ namespace ArchiSteamFarm {
 						break;
 					}
 
-					HashSet<Steam.Asset> itemsToGive = Trading.GetTradableItemsFromInventory(ourInventory, classIDsToGive);
-					HashSet<Steam.Asset> itemsToReceive = Trading.GetTradableItemsFromInventory(theirInventory, classIDsToReceive);
+					HashSet<Steam.Asset> itemsToGive = Trading.GetTradableItemsFromInventory(ourInventory.Select(item => item.CreateShallowCopy()).ToHashSet(), classIDsToGive);
+					HashSet<Steam.Asset> itemsToReceive = Trading.GetTradableItemsFromInventory(theirInventory.Select(item => item.CreateShallowCopy()).ToHashSet(), classIDsToReceive);
 
 					if ((itemsToGive.Count != itemsToReceive.Count) || !Trading.IsFairExchange(itemsToGive, itemsToReceive)) {
 						// Failsafe

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -477,7 +477,7 @@ namespace ArchiSteamFarm {
 										fairClassIDsToReceive[theirItem] = ++fairReceivedAmount;
 										
 										// Filter their inventory for the sets we're trading or have traded with this user
-										HashSet<Steam.Asset> fairFiltered = new HashSet<Steam.Asset>(theirInventory.Where(item => (item.RealAppID == set.RealAppID) && (item.Type == set.Type) && (item.Rarity == set.Rarity) || skippedSetsThisTrade.Any(skippedSets => skippedSets.RealAppID == item.RealAppID && skippedSets.Type == item.Type && skippedSets.Rarity == item.Rarity)).Select(item => item.CreateShallowCopy()).ToHashSet());
+										HashSet<Steam.Asset> fairFiltered = theirInventory.Where(item => (item.RealAppID == set.RealAppID) && (item.Type == set.Type) && (item.Rarity == set.Rarity) || skippedSetsThisTrade.Any(skippedSets => skippedSets.RealAppID == item.RealAppID && skippedSets.Type == item.Type && skippedSets.Rarity == item.Rarity)).Select(item => item.CreateShallowCopy()).ToHashSet();
 
 										// Copy list to HashSet<Steam.Asset>
 										HashSet<Steam.Asset> fairItemsToGive = Trading.GetTradableItemsFromInventory(ourInventory.Where(item => (item.RealAppID == set.RealAppID && item.Type == set.Type && item.Rarity == set.Rarity) || skippedSetsThisTrade.Any(skippedSets => skippedSets.RealAppID == item.RealAppID && skippedSets.Type == item.Type && skippedSets.Rarity == item.Rarity)).Select(item => item.CreateShallowCopy()).ToHashSet(), fairClassIDsToGive.ToDictionary(classID => classID.Key, classID => classID.Value));

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -483,8 +483,10 @@ namespace ArchiSteamFarm {
 
 									if (!listedUser.MatchEverything) {
 										// We have a potential match, let's check fairness for them
-										fairClassIDsToGive[ourItem] = fairClassIDsToGive.TryGetValue(ourItem, out uint fairGivenAmount) ? fairGivenAmount + 1 : 1;
-										fairClassIDsToReceive[theirItem] = fairClassIDsToReceive.TryGetValue(theirItem, out uint fairReceivedAmount) ? fairReceivedAmount + 1 : 1;
+										fairClassIDsToGive.TryGetValue(ourItem, out uint fairGivenAmount);
+										fairClassIDsToReceive.TryGetValue(theirItem, out uint fairReceivedAmount);
+										fairClassIDsToGive[ourItem] = ++fairGivenAmount;
+										fairClassIDsToReceive[theirItem] = ++fairReceivedAmount;
 
 										// Convert list to HashSet<Steam.Asset>
 										HashSet<Steam.Asset> fairItemsToGive = Trading.GetTradableItemsFromInventory(ourInventory, fairClassIDsToGive);

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -217,6 +217,28 @@ namespace ArchiSteamFarm {
 			return (fullState, tradableState);
 		}
 
+		internal static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), Dictionary<ulong, uint>> GetTradableInventoryState(IReadOnlyCollection<Steam.Asset> inventory) {
+			if ((inventory == null) || (inventory.Count == 0)) {
+				ASF.ArchiLogger.LogNullError(nameof(inventory));
+
+				return null;
+			}
+
+			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), Dictionary<ulong, uint>> tradableState = new Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), Dictionary<ulong, uint>>();
+
+			foreach (Steam.Asset item in inventory.Where(item => item.Tradable)) {
+				(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) key = (item.RealAppID, item.Type, item.Rarity);
+
+				if (tradableState.TryGetValue(key, out Dictionary<ulong, uint> tradableSet)) {
+					tradableSet[item.ClassID] = tradableSet.TryGetValue(item.ClassID, out uint amount) ? amount + item.Amount : item.Amount;
+				} else {
+					tradableState[key] = new Dictionary<ulong, uint> { { item.ClassID, item.Amount } };
+				}
+			}
+
+			return tradableState;
+		}
+
 		internal static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), Dictionary<ulong, uint>> GetInventoryState(IReadOnlyCollection<Steam.Asset> inventory) {
 			if ((inventory == null) || (inventory.Count == 0)) {
 				ASF.ArchiLogger.LogNullError(nameof(inventory));


### PR DESCRIPTION
This adds fair trading to `MatchActively()`. There's probably a lot to improve but it should already work fine.

The most trouble gave me `IsTradeNeutralOrBetter()` because it already expects a filtered inventory. So the big ugly added block of code is mostly to accomplish that.