### PR TITLE
Extra BotBehaviour options to mark as read only messages from bots, and only incoming trade offer messages

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -36,6 +36,7 @@ using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.NLog;
 using ArchiSteamFarm.Plugins;
 using JetBrains.Annotations;
+using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using SteamKit2;
 using SteamKit2.Unified.Internal;
@@ -2194,6 +2195,32 @@ namespace ArchiSteamFarm {
 			await Actions.AcceptGuestPasses(guestPassIDs).ConfigureAwait(false);
 		}
 
+		private bool ShouldMarkGroupChatMessage(ulong steamID) {
+			if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead)) {
+				return true;
+			}
+
+			if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotMessagesAsRead) &&
+				Bots.Values.Any(bot => bot.SteamID == steamID)) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private bool ShouldMarkPrivateChatMessage(ulong steamID, string message) {
+			if (ShouldMarkGroupChatMessage(steamID)) {
+				return true;
+			}
+
+			if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkTradeMessagesAsRead) &&
+				message.StartsWith("[tradeoffer", StringComparison.Ordinal)) {
+				return true;
+			}
+
+			return false;
+		}
+
 		private async Task OnIncomingChatMessage(CChatRoom_IncomingChatMessage_Notification notification) {
 			if (notification == null) {
 				ArchiLogger.LogNullError(nameof(notification));
@@ -2202,11 +2229,10 @@ namespace ArchiSteamFarm {
 			}
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
-			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0) &&
-				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
-					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotMessagesAsRead) &&
-					Bots.Values.Any(bot => bot.SteamID == notification.steamid_sender)))) {
-				Utilities.InBackground(() => ArchiHandler.AckChatMessage(notification.chat_group_id, notification.chat_id, notification.timestamp));
+			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0)) {
+				if (ShouldMarkGroupChatMessage(notification.steamid_sender)) {
+					Utilities.InBackground(() => ArchiHandler.AckChatMessage(notification.chat_group_id, notification.chat_id, notification.timestamp));
+				}
 			}
 
 			string message;
@@ -2245,13 +2271,10 @@ namespace ArchiSteamFarm {
 			}
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
-			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0) &&
-				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
-					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotMessagesAsRead) &&
-					Bots.Values.Any(bot => bot.SteamID == notification.steamid_friend)) ||
-					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkTradeMessagesAsRead) &&
-					notification.message.StartsWith("[tradeoffer", StringComparison.Ordinal)))) {
-				Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
+			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0)) {
+				if (ShouldMarkPrivateChatMessage(notification.steamid_friend, notification.message)) {
+					Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
+				}
 			}
 
 			string message;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2195,7 +2195,7 @@ namespace ArchiSteamFarm {
 			await Actions.AcceptGuestPasses(guestPassIDs).ConfigureAwait(false);
 		}
 
-		private bool ShouldMarkGroupChatMessage(ulong steamID) {
+		private bool ShouldAckGroupChatMessage(ulong steamID) {
 			if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead)) {
 				return true;
 			}
@@ -2208,8 +2208,8 @@ namespace ArchiSteamFarm {
 			return false;
 		}
 
-		private bool ShouldMarkPrivateChatMessage(ulong steamID, string message) {
-			if (ShouldMarkGroupChatMessage(steamID)) {
+		private bool ShouldAckPrivateChatMessage(ulong steamID, string message) {
+			if (ShouldAckGroupChatMessage(steamID)) {
 				return true;
 			}
 
@@ -2230,7 +2230,7 @@ namespace ArchiSteamFarm {
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
 			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0)) {
-				if (ShouldMarkGroupChatMessage(notification.steamid_sender)) {
+				if (ShouldAckGroupChatMessage(notification.steamid_sender)) {
 					Utilities.InBackground(() => ArchiHandler.AckChatMessage(notification.chat_group_id, notification.chat_id, notification.timestamp));
 				}
 			}
@@ -2272,7 +2272,7 @@ namespace ArchiSteamFarm {
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
 			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0)) {
-				if (ShouldMarkPrivateChatMessage(notification.steamid_friend, notification.message)) {
+				if (ShouldAckPrivateChatMessage(notification.steamid_friend, notification.message)) {
 					Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
 				}
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2242,9 +2242,12 @@ namespace ArchiSteamFarm {
 			}
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
-			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0) && BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead)) {
-				Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
-			}
+			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0))
+				if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
+					((Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_friend) != null) &&
+					 BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead))) {
+					Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
+				}
 
 			string message;
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2202,7 +2202,10 @@ namespace ArchiSteamFarm {
 			}
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
-			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0) && BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead)) {
+			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0) &&
+				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
+					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead) &&
+					(Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_sender) != null)))) {
 				Utilities.InBackground(() => ArchiHandler.AckChatMessage(notification.chat_group_id, notification.chat_id, notification.timestamp));
 			}
 
@@ -2242,12 +2245,14 @@ namespace ArchiSteamFarm {
 			}
 
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
-			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0))
-				if (BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
-					((Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_friend) != null) &&
-					 BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead))) {
-					Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
-				}
+			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0) &&
+				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
+					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead) &&
+					(Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_friend) != null)) ||
+					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkTradeMessagesAsRead) &&
+					notification.message.StartsWith("[tradeoffer", StringComparison.Ordinal)))) {
+				Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));
+			}
 
 			string message;
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2204,8 +2204,8 @@ namespace ArchiSteamFarm {
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
 			if ((notification.steamid_sender != SteamID) && (notification.timestamp > 0) &&
 				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
-					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead) &&
-					(Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_sender) != null)))) {
+					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotMessagesAsRead) &&
+					Bots.Values.Any(bot => bot.SteamID == notification.steamid_sender)))) {
 				Utilities.InBackground(() => ArchiHandler.AckChatMessage(notification.chat_group_id, notification.chat_id, notification.timestamp));
 			}
 
@@ -2247,8 +2247,8 @@ namespace ArchiSteamFarm {
 			// Under normal circumstances, timestamp must always be greater than 0, but Steam already proved that it's capable of going against the logic
 			if (!notification.local_echo && (notification.rtime32_server_timestamp > 0) &&
 				(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkReceivedMessagesAsRead) ||
-					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotsMessagesAsRead) &&
-					(Bot.Bots.Values.FirstOrDefault(bot => bot.SteamID == notification.steamid_friend) != null)) ||
+					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkBotMessagesAsRead) &&
+					Bots.Values.Any(bot => bot.SteamID == notification.steamid_friend)) ||
 					(BotConfig.BotBehaviour.HasFlag(BotConfig.EBotBehaviour.MarkTradeMessagesAsRead) &&
 					notification.message.StartsWith("[tradeoffer", StringComparison.Ordinal)))) {
 				Utilities.InBackground(() => ArchiHandler.AckMessage(notification.steamid_friend, notification.rtime32_server_timestamp));

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -387,7 +387,8 @@ namespace ArchiSteamFarm {
 			DismissInventoryNotifications = 8,
 			MarkReceivedMessagesAsRead = 16,
 			MarkBotsMessagesAsRead = 32,
-			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead | MarkBotsMessagesAsRead
+			MarkTradeMessagesAsRead = 64,
+			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead | MarkBotsMessagesAsRead | MarkTradeMessagesAsRead
 		}
 
 		public enum EFarmingOrder : byte {

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -386,7 +386,8 @@ namespace ArchiSteamFarm {
 			RejectInvalidGroupInvites = 4,
 			DismissInventoryNotifications = 8,
 			MarkReceivedMessagesAsRead = 16,
-			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead
+			MarkBotsMessagesAsRead = 32,
+			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead | MarkBotsMessagesAsRead
 		}
 
 		public enum EFarmingOrder : byte {

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -386,9 +386,9 @@ namespace ArchiSteamFarm {
 			RejectInvalidGroupInvites = 4,
 			DismissInventoryNotifications = 8,
 			MarkReceivedMessagesAsRead = 16,
-			MarkBotsMessagesAsRead = 32,
+			MarkBotMessagesAsRead = 32,
 			MarkTradeMessagesAsRead = 64,
-			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead | MarkBotsMessagesAsRead | MarkTradeMessagesAsRead
+			All = RejectInvalidFriendInvites | RejectInvalidTrades | RejectInvalidGroupInvites | DismissInventoryNotifications | MarkReceivedMessagesAsRead | MarkBotMessagesAsRead | MarkTradeMessagesAsRead
 		}
 
 		public enum EFarmingOrder : byte {


### PR DESCRIPTION
## New `BotBehaviour` options

### Purpose

Those new options are mainly purposed for the case of using main steam account in same asf instance as other bots. On main steam account `MarkReceivedMessagesAsRead` is not a best idea, as it would also mark as read incoming messages from your friends, but it would be nice to automatically mark messages from bots as read. Also, chat messages about new incoming trades seems kinda excessive, and steam has no option to disable those, so I made another ASF option to address this too.

### Implementation

This PR adds two extra options for `BotBehaviour` configuration parameter:
`MarkBotsMessagesAsRead` - bot will mark as read any messages from other bots in the same ASF instance
`MarkTradeMessagesAsRead` - bot will mark as read any **chat** messages about new incoming trades. Steam shows new incoming trade notifications anyway, so usually there is no reason to have it duplicated in chat. This includes not only trade offers from other bots, but any incoming trades from users in your friendlist.

