### PR TITLE
Match assets with descriptions by instance IDs as well

### DIFF
--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -183,7 +183,7 @@ namespace ArchiSteamFarm {
 						return null;
 					}
 
-					Dictionary<ulong, (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> descriptions = new Dictionary<ulong, (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)>();
+					Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> descriptions = new Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)>();
 
 					foreach (Steam.InventoryResponse.Description description in response.Descriptions.Where(description => description != null)) {
 						if (description.ClassID == 0) {
@@ -192,15 +192,11 @@ namespace ArchiSteamFarm {
 							return null;
 						}
 
-						if (descriptions.ContainsKey(description.ClassID)) {
-							continue;
-						}
-
-						descriptions[description.ClassID] = (description.Marketable, description.Tradable, description.RealAppID, description.Type, description.Rarity);
+						descriptions[(description.ClassID, description.InstanceID)] = (description.Marketable, description.Tradable, description.RealAppID, description.Type, description.Rarity);
 					}
 
 					foreach (Steam.Asset asset in response.Assets.Where(asset => asset != null)) {
-						if (descriptions.TryGetValue(asset.ClassID, out (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) description)) {
+						if (descriptions.TryGetValue((asset.ClassID, asset.InstanceID), out (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) description)) {
 							if ((marketable.HasValue && (description.Marketable != marketable.Value)) || (tradable.HasValue && (description.Tradable != tradable.Value)) || (wantedRealAppIDs?.Contains(description.RealAppID) == false) || (unwantedRealAppIDs?.Contains(description.RealAppID) == true) || (wantedTypes?.Contains(description.Type) == false) || (wantedSets?.Contains((description.RealAppID, description.Type, description.Rarity)) == false)) {
 								continue;
 							}

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -478,8 +478,8 @@ namespace ArchiSteamFarm.Json {
 				internal readonly uint AppID;
 
 				internal ulong ClassID { get; private set; }
-				internal bool Marketable { get; private set; }
 				internal ulong InstanceID { get; private set; }
+				internal bool Marketable { get; private set; }
 				internal Asset.ERarity Rarity { get; private set; }
 				internal uint RealAppID { get; private set; }
 				internal bool Tradable { get; private set; }

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -56,6 +56,9 @@ namespace ArchiSteamFarm.Json {
 			public ulong ContextID { get; private set; }
 
 			[PublicAPI]
+			public ulong InstanceID { get; private set; }
+
+			[PublicAPI]
 			public bool Marketable { get; internal set; }
 
 			[PublicAPI]
@@ -168,6 +171,25 @@ namespace ArchiSteamFarm.Json {
 			private string IDText {
 				get => AssetIDText;
 				set => AssetIDText = value;
+			}
+#pragma warning restore IDE0051
+
+#pragma warning disable IDE0051
+			[JsonProperty(PropertyName = "instanceid", Required = Required.DisallowNull)]
+			private string InstanceIDText {
+				set {
+					if (string.IsNullOrEmpty(value)) {
+						return;
+					}
+
+					if (!ulong.TryParse(value, out ulong instanceID)) {
+						ASF.ArchiLogger.LogNullError(nameof(instanceID));
+
+						return;
+					}
+
+					InstanceID = instanceID;
+				}
 			}
 #pragma warning restore IDE0051
 
@@ -457,6 +479,7 @@ namespace ArchiSteamFarm.Json {
 
 				internal ulong ClassID { get; private set; }
 				internal bool Marketable { get; private set; }
+				internal ulong InstanceID { get; private set; }
 				internal Asset.ERarity Rarity { get; private set; }
 				internal uint RealAppID { get; private set; }
 				internal bool Tradable { get; private set; }
@@ -479,6 +502,25 @@ namespace ArchiSteamFarm.Json {
 						}
 
 						ClassID = classID;
+					}
+				}
+#pragma warning restore IDE0051
+
+#pragma warning disable IDE0051
+				[JsonProperty(PropertyName = "instanceid", Required = Required.DisallowNull)]
+				private string InstanceIDText {
+					set {
+						if (string.IsNullOrEmpty(value)) {
+							return;
+						}
+
+						if (!ulong.TryParse(value, out ulong instanceID)) {
+							ASF.ArchiLogger.LogNullError(nameof(instanceID));
+
+							return;
+						}
+
+						InstanceID = instanceID;
 					}
 				}
 #pragma warning restore IDE0051


### PR DESCRIPTION
Use instance IDs for matching descriptions. Old behaviour didn't take that into account, which leads to incorrect inventory parsing (e.g. items with different marketability/tradeability are treated incorrectly). Same algorithm is used by Steam code as well: 
![image](https://user-images.githubusercontent.com/24438339/73580547-fdad5600-4496-11ea-9272-b8893bc93488.png)
