### PR TITLE
Use IAsyncEnumerable for getting inventory

### DIFF
--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -282,7 +282,7 @@ namespace ArchiSteamFarm {
 					TradingScheduled = false;
 				}
 
-				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventory(Bot.SteamID, appID, contextID, tradable: true, wantedRealAppIDs: wantedRealAppIDs, unwantedRealAppIDs: unwantedRealAppIDs, wantedTypes: wantedTypes).ConfigureAwait(false);
+				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(true) && !(unwantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(false) && (wantedTypes?.Contains(item.Type)).GetValueOrDefault(true)).ToHashSetAsync().ConfigureAwait(false);
 
 				if ((inventory == null) || (inventory.Count == 0)) {
 					return (false, string.Format(Strings.ErrorIsEmpty, nameof(inventory)));

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -22,8 +22,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Collections;
@@ -287,7 +287,7 @@ namespace ArchiSteamFarm {
 
 				try {
 					inventory = await Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ToHashSetAsync().ConfigureAwait(false);
-				} catch (IOException e) {
+				} catch (HttpRequestException e) {
 					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 				} catch (Exception e) {
 					Bot.ArchiLogger.LogGenericException(e);

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -285,12 +285,12 @@ namespace ArchiSteamFarm {
 				HashSet<Steam.Asset> inventory;
 
 				try {
-					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(true) && !(unwantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(false) && (wantedTypes?.Contains(item.Type)).GetValueOrDefault(true)).ToHashSetAsync().ConfigureAwait(false);
+					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ToHashSetAsync().ConfigureAwait(false);
 				} catch (Exception e) {
 					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 				}
 
-				if ((inventory == null) || (inventory.Count == 0)) {
+				if (inventory.Count == 0) {
 					return (false, string.Format(Strings.ErrorIsEmpty, nameof(inventory)));
 				}
 

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -282,7 +282,13 @@ namespace ArchiSteamFarm {
 					TradingScheduled = false;
 				}
 
-				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(true) && !(unwantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(false) && (wantedTypes?.Contains(item.Type)).GetValueOrDefault(true)).ToHashSetAsync().ConfigureAwait(false);
+				HashSet<Steam.Asset> inventory;
+
+				try {
+					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(true) && !(unwantedRealAppIDs?.Contains(item.RealAppID)).GetValueOrDefault(false) && (wantedTypes?.Contains(item.Type)).GetValueOrDefault(true)).ToHashSetAsync().ConfigureAwait(false);
+				} catch (Exception e) {
+					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
+				}
 
 				if ((inventory == null) || (inventory.Count == 0)) {
 					return (false, string.Format(Strings.ErrorIsEmpty, nameof(inventory)));

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -287,6 +287,7 @@ namespace ArchiSteamFarm {
 				try {
 					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ToHashSetAsync().ConfigureAwait(false);
 				} catch (Exception e) {
+					// Returning exception message instead of logging it
 					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 				}
 

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -285,9 +286,12 @@ namespace ArchiSteamFarm {
 				HashSet<Steam.Asset> inventory;
 
 				try {
-					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ToHashSetAsync().ConfigureAwait(false);
+					inventory = await Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID, appID, contextID).Where(item => item.Tradable && (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ToHashSetAsync().ConfigureAwait(false);
+				} catch (IOException e) {
+					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 				} catch (Exception e) {
-					// Returning exception message instead of logging it
+					Bot.ArchiLogger.LogGenericException(e);
+
 					return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 				}
 

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -248,12 +248,12 @@ namespace ArchiSteamFarm {
 				return (false, string.Format(Strings.ErrorObjectIsNull, nameof(wantedRealAppIDs) + " || " + nameof(unwantedRealAppIDs) + " || " + nameof(wantedTypes)));
 			}
 
-			return await SendTradeOfferAsync(appID, contextID, targetSteamID, tradeToken, item => (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ConfigureAwait(false);
+			return await SendInventory(appID, contextID, targetSteamID, tradeToken, item => (wantedRealAppIDs?.Contains(item.RealAppID) != false) && (unwantedRealAppIDs?.Contains(item.RealAppID) != true) && (wantedTypes?.Contains(item.Type) != false)).ConfigureAwait(false);
 		}
 
 		[PublicAPI]
 		[SuppressMessage("ReSharper", "FunctionComplexityOverflow")]
-		public async Task<(bool Success, string Message)> SendTradeOfferAsync(uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, ulong targetSteamID = 0, string tradeToken = null, Func<Steam.Asset, bool> filterFunction = null) {
+		public async Task<(bool Success, string Message)> SendInventory(uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, ulong targetSteamID = 0, string tradeToken = null, Func<Steam.Asset, bool> filterFunction = null) {
 			if ((appID == 0) || (contextID == 0)) {
 				Bot.ArchiLogger.LogNullError(nameof(appID) + " || " + nameof(contextID));
 

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -69,6 +69,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.0.0" />
     <PackageReference Include="System.Composition" Version="1.4.0" />
+    <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <Reference Include="SteamKit2">
       <HintPath>lib\SteamKit2.dll</HintPath>
     </Reference>

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -133,7 +133,7 @@ namespace ArchiSteamFarm {
 			}
 
 			try {
-				return await GetInventoryEnumerable(steamID, appID, contextID).Where(
+				return await GetInventoryAsync(steamID, appID, contextID).Where(
 					item =>
 						(!marketable.HasValue || (item.Marketable == marketable.Value)) &&
 						(!tradable.HasValue || (item.Tradable == tradable.Value)) &&
@@ -154,7 +154,7 @@ namespace ArchiSteamFarm {
 		[JetBrains.Annotations.NotNull]
 		[PublicAPI]
 		[SuppressMessage("ReSharper", "FunctionComplexityOverflow")]
-		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID) {
+		public async IAsyncEnumerable<Steam.Asset> GetInventoryAsync(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID) {
 			if ((appID == 0) || (contextID == 0)) {
 				throw new ArgumentException(string.Format(Strings.ErrorObjectIsNull, nameof(appID) + " || " + nameof(contextID)));
 			}
@@ -192,7 +192,7 @@ namespace ArchiSteamFarm {
 					}
 
 					if (!response.Success) {
-						throw new Exception(!string.IsNullOrEmpty(response.Error) ? string.Format(Strings.WarningFailedWithError, response.Error) : Strings.WarningFailed);
+						throw new IOException(!string.IsNullOrEmpty(response.Error) ? string.Format(Strings.WarningFailedWithError, response.Error) : Strings.WarningFailed);
 					}
 
 					if (response.TotalInventoryCount == 0) {

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -131,7 +131,7 @@ namespace ArchiSteamFarm {
 			}
 
 			try {
-				return await GetInventoryEnumerable(steamID, appID, contextID, marketable, tradable, wantedRealAppIDs, unwantedRealAppIDs, wantedTypes, wantedSets, false).ToHashSetAsync().ConfigureAwait(false);
+				return await GetInventoryEnumerable(steamID, appID, contextID, marketable, tradable, wantedRealAppIDs, unwantedRealAppIDs, wantedTypes, wantedSets).ToHashSetAsync().ConfigureAwait(false);
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
 
@@ -141,15 +141,9 @@ namespace ArchiSteamFarm {
 
 		[PublicAPI]
 		[SuppressMessage("ReSharper", "FunctionComplexityOverflow")]
-		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, bool? marketable = null, bool? tradable = null, IReadOnlyCollection<uint> wantedRealAppIDs = null, IReadOnlyCollection<uint> unwantedRealAppIDs = null, IReadOnlyCollection<Steam.Asset.EType> wantedTypes = null, IReadOnlyCollection<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> wantedSets = null, bool suppressExceptions = true) {
+		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, bool? marketable = null, bool? tradable = null, IReadOnlyCollection<uint> wantedRealAppIDs = null, IReadOnlyCollection<uint> unwantedRealAppIDs = null, IReadOnlyCollection<Steam.Asset.EType> wantedTypes = null, IReadOnlyCollection<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> wantedSets = null) {
 			if ((appID == 0) || (contextID == 0)) {
-				if (!suppressExceptions) {
-					throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(appID) + " || " + nameof(contextID)));
-				}
-
-				Bot.ArchiLogger.LogNullError(nameof(appID) + " || " + nameof(contextID));
-
-				yield break;
+				throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(appID) + " || " + nameof(contextID)));
 			}
 
 			if (steamID == 0) {
@@ -159,25 +153,13 @@ namespace ArchiSteamFarm {
 					}
 
 					if (!Initialized) {
-						if (!suppressExceptions) {
-							throw new Exception(Strings.WarningFailed);
-						}
-
-						Bot.ArchiLogger.LogGenericWarning(Strings.WarningFailed);
-
-						yield break;
+						throw new Exception(Strings.WarningFailed);
 					}
 				}
 
 				steamID = Bot.SteamID;
 			} else if (!new SteamID(steamID).IsIndividualAccount) {
-				if (!suppressExceptions) {
-					throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(steamID)));
-				}
-
-				Bot.ArchiLogger.LogNullError(nameof(steamID));
-
-				yield break;
+				throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(steamID)));
 			}
 
 			string request = "/inventory/" + steamID + "/" + appID + "/" + contextID + "?count=" + MaxItemsInSingleInventoryRequest + "&l=english";
@@ -190,23 +172,11 @@ namespace ArchiSteamFarm {
 					Steam.InventoryResponse response = await UrlGetToJsonObjectWithSession<Steam.InventoryResponse>(SteamCommunityURL, request + (startAssetID > 0 ? "&start_assetid=" + startAssetID : "")).ConfigureAwait(false);
 
 					if (response == null) {
-						if (!suppressExceptions) {
-							throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response)));
-						}
-
-						yield break;
+						throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response)));
 					}
 
 					if (!response.Success) {
-						string errorMessage = !string.IsNullOrEmpty(response.Error) ? string.Format(Strings.WarningFailedWithError, response.Error) : Strings.WarningFailed;
-
-						if (!suppressExceptions) {
-							throw new Exception(errorMessage);
-						}
-
-						Bot.ArchiLogger.LogGenericWarning(errorMessage);
-
-						yield break;
+						throw new Exception(!string.IsNullOrEmpty(response.Error) ? string.Format(Strings.WarningFailedWithError, response.Error) : Strings.WarningFailed);
 					}
 
 					if (response.TotalInventoryCount == 0) {
@@ -215,26 +185,14 @@ namespace ArchiSteamFarm {
 					}
 
 					if ((response.Assets == null) || (response.Assets.Count == 0) || (response.Descriptions == null) || (response.Descriptions.Count == 0)) {
-						if (!suppressExceptions) {
-							throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response.Assets) + " || " + nameof(response.Descriptions)));
-						}
-
-						Bot.ArchiLogger.LogNullError(nameof(response.Assets) + " || " + nameof(response.Descriptions));
-
-						yield break;
+						throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response.Assets) + " || " + nameof(response.Descriptions)));
 					}
 
 					Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> descriptions = new Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)>();
 
 					foreach (Steam.InventoryResponse.Description description in response.Descriptions.Where(description => description != null)) {
 						if (description.ClassID == 0) {
-							if (!suppressExceptions) {
-								throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(description.ClassID)));
-							}
-
-							Bot.ArchiLogger.LogNullError(nameof(description.ClassID));
-
-							yield break;
+							throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(description.ClassID)));
 						}
 
 						(ulong ClassID, ulong InstanceID) key = (description.ClassID, description.InstanceID);
@@ -269,13 +227,7 @@ namespace ArchiSteamFarm {
 					}
 
 					if (response.LastAssetID == 0) {
-						if (!suppressExceptions) {
-							throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response.LastAssetID)));
-						}
-
-						Bot.ArchiLogger.LogNullError(nameof(response.LastAssetID));
-
-						yield break;
+						throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(response.LastAssetID)));
 					}
 
 					startAssetID = response.LastAssetID;

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -139,7 +139,8 @@ namespace ArchiSteamFarm {
 						(!tradable.HasValue || (item.Tradable == tradable.Value)) &&
 						(wantedRealAppIDs?.Contains(item.RealAppID) != false) &&
 						(unwantedRealAppIDs?.Contains(item.RealAppID) != true) &&
-						(wantedTypes?.Contains(item.Type) != false)
+						(wantedTypes?.Contains(item.Type) != false) &&
+						(wantedSets?.Contains((item.RealAppID, item.Type, item.Rarity)) != false)
 				).ToHashSetAsync().ConfigureAwait(false);
 			} catch (IOException) {
 				return null;

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -144,7 +144,7 @@ namespace ArchiSteamFarm {
 			} catch (IOException) {
 				return null;
 			} catch (Exception e) {
-				Bot.ArchiLogger.LogGenericWarningException(e);
+				Bot.ArchiLogger.LogGenericException(e);
 
 				return null;
 			}

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -123,7 +123,7 @@ namespace ArchiSteamFarm {
 
 		[ItemCanBeNull]
 		[PublicAPI]
-		public async Task<HashSet<Steam.Asset>> GetInventory(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, bool? marketable = null, bool? tradable = null, IReadOnlyCollection<uint> wantedRealAppIDs = null, IReadOnlyCollection<uint> unwantedRealAppIDs = null, IReadOnlyCollection<Steam.Asset.EType> wantedTypes = null, IReadOnlyCollection<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> wantedSets = null) {
+		public async Task<HashSet<Steam.Asset>> GetInventory(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID) {
 			if ((appID == 0) || (contextID == 0)) {
 				Bot.ArchiLogger.LogNullError(nameof(appID) + " || " + nameof(contextID));
 
@@ -131,7 +131,7 @@ namespace ArchiSteamFarm {
 			}
 
 			try {
-				return await GetInventoryEnumerable(steamID, appID, contextID, marketable, tradable, wantedRealAppIDs, unwantedRealAppIDs, wantedTypes, wantedSets).ToHashSetAsync().ConfigureAwait(false);
+				return await GetInventoryEnumerable(steamID, appID, contextID).ToHashSetAsync().ConfigureAwait(false);
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
 
@@ -141,7 +141,7 @@ namespace ArchiSteamFarm {
 
 		[PublicAPI]
 		[SuppressMessage("ReSharper", "FunctionComplexityOverflow")]
-		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID, bool? marketable = null, bool? tradable = null, IReadOnlyCollection<uint> wantedRealAppIDs = null, IReadOnlyCollection<uint> unwantedRealAppIDs = null, IReadOnlyCollection<Steam.Asset.EType> wantedTypes = null, IReadOnlyCollection<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> wantedSets = null) {
+		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID) {
 			if ((appID == 0) || (contextID == 0)) {
 				throw new Exception(string.Format(Strings.ErrorObjectIsNull, nameof(appID) + " || " + nameof(contextID)));
 			}
@@ -206,10 +206,6 @@ namespace ArchiSteamFarm {
 
 					foreach (Steam.Asset asset in response.Assets.Where(asset => asset != null)) {
 						if (!descriptions.TryGetValue((asset.ClassID, asset.InstanceID), out (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) description)) {
-							continue;
-						}
-
-						if ((marketable.HasValue && (description.Marketable != marketable.Value)) || (tradable.HasValue && (description.Tradable != tradable.Value)) || (wantedRealAppIDs?.Contains(description.RealAppID) == false) || (unwantedRealAppIDs?.Contains(description.RealAppID) == true) || (wantedTypes?.Contains(description.Type) == false) || (wantedSets?.Contains((description.RealAppID, description.Type, description.Rarity)) == false)) {
 							continue;
 						}
 

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -140,6 +140,7 @@ namespace ArchiSteamFarm {
 			}
 		}
 
+		[JetBrains.Annotations.NotNull]
 		[PublicAPI]
 		[SuppressMessage("ReSharper", "FunctionComplexityOverflow")]
 		public async IAsyncEnumerable<Steam.Asset> GetInventoryEnumerable(ulong steamID = 0, uint appID = Steam.Asset.SteamAppID, ulong contextID = Steam.Asset.SteamCommunityContextID) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1027,7 +1027,7 @@ namespace ArchiSteamFarm {
 			if (BotConfig.SendOnFarmingFinished && (BotConfig.LootableTypes.Count > 0) && (farmedSomething || !FirstTradeSent)) {
 				FirstTradeSent = true;
 
-				await Actions.SendTradeOffer(wantedTypes: BotConfig.LootableTypes).ConfigureAwait(false);
+				await Actions.SendTradeOfferAsync(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 			}
 
 			if (BotConfig.ShutdownOnFarmingFinished) {
@@ -1808,7 +1808,7 @@ namespace ArchiSteamFarm {
 
 			if ((BotConfig.SendTradePeriod > 0) && (BotConfig.LootableTypes.Count > 0) && BotConfig.SteamUserPermissions.Values.Any(permission => permission >= BotConfig.EPermission.Master)) {
 				SendItemsTimer = new Timer(
-					async e => await Actions.SendTradeOffer(wantedTypes: BotConfig.LootableTypes).ConfigureAwait(false),
+					async e => await Actions.SendTradeOfferAsync(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false),
 					null,
 					TimeSpan.FromHours(BotConfig.SendTradePeriod) + TimeSpan.FromSeconds(ASF.LoadBalancingDelay * Bots.Count), // Delay
 					TimeSpan.FromHours(BotConfig.SendTradePeriod) // Period

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1027,7 +1027,7 @@ namespace ArchiSteamFarm {
 			if (BotConfig.SendOnFarmingFinished && (BotConfig.LootableTypes.Count > 0) && (farmedSomething || !FirstTradeSent)) {
 				FirstTradeSent = true;
 
-				await Actions.SendTradeOfferAsync(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
+				await Actions.SendInventory(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 			}
 
 			if (BotConfig.ShutdownOnFarmingFinished) {
@@ -1808,7 +1808,7 @@ namespace ArchiSteamFarm {
 
 			if ((BotConfig.SendTradePeriod > 0) && (BotConfig.LootableTypes.Count > 0) && BotConfig.SteamUserPermissions.Values.Any(permission => permission >= BotConfig.EPermission.Master)) {
 				SendItemsTimer = new Timer(
-					async e => await Actions.SendTradeOfferAsync(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false),
+					async e => await Actions.SendInventory(filterFunction: item => BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false),
 					null,
 					TimeSpan.FromHours(BotConfig.SendTradePeriod) + TimeSpan.FromSeconds(ASF.LoadBalancingDelay * Bots.Count), // Delay
 					TimeSpan.FromHours(BotConfig.SendTradePeriod) // Period

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -190,7 +190,7 @@ namespace ArchiSteamFarm {
 			// If we're not farming, and we got new items, it's likely to be a booster pack or likewise
 			// In this case, perform a loot if user wants to do so
 			if (Bot.BotConfig.SendOnFarmingFinished && (Bot.BotConfig.LootableTypes.Count > 0)) {
-				await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
+				await Bot.Actions.SendInventory(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 			}
 		}
 

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -190,7 +190,7 @@ namespace ArchiSteamFarm {
 			// If we're not farming, and we got new items, it's likely to be a booster pack or likewise
 			// In this case, perform a loot if user wants to do so
 			if (Bot.BotConfig.SendOnFarmingFinished && (Bot.BotConfig.LootableTypes.Count > 0)) {
-				await Bot.Actions.SendTradeOffer(wantedTypes: Bot.BotConfig.LootableTypes).ConfigureAwait(false);
+				await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 			}
 		}
 

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -654,7 +654,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(string.Format(Strings.ErrorIsInvalid, nameof(contextID)));
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(appID, contextID).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(appID, contextID).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -799,7 +799,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.TargetBotNotConnected);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(appID, contextID, targetBot.SteamID).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(appID, contextID, targetBot.SteamID).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -1504,7 +1504,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(string.Format(Strings.ErrorIsEmpty, nameof(Bot.BotConfig.LootableTypes)));
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(wantedTypes: Bot.BotConfig.LootableTypes).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -1565,7 +1565,7 @@ namespace ArchiSteamFarm {
 				realAppIDs.Add(appID);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(wantedTypes: Bot.BotConfig.LootableTypes, wantedRealAppIDs: !exclude ? realAppIDs : null, unwantedRealAppIDs: exclude ? realAppIDs : null).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -2692,7 +2692,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotSendingTradeToYourself);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(targetSteamID: targetBot.SteamID, wantedTypes: Bot.BotConfig.TransferableTypes).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type)).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -2745,7 +2745,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotSendingTradeToYourself);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOffer(targetSteamID: targetBot.SteamID, wantedTypes: Bot.BotConfig.TransferableTypes, wantedRealAppIDs: !exclude ? realAppIDs : null, unwantedRealAppIDs: exclude ? realAppIDs : null).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2866,7 +2866,7 @@ namespace ArchiSteamFarm {
 			} catch (IOException) {
 				completeSuccess = false;
 			} catch (Exception e) {
-				Bot.ArchiLogger.LogGenericWarningException(e);
+				Bot.ArchiLogger.LogGenericException(e);
 
 				completeSuccess = false;
 			}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -22,8 +22,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -2863,7 +2863,7 @@ namespace ArchiSteamFarm {
 						completeSuccess = false;
 					}
 				}
-			} catch (IOException) {
+			} catch (HttpRequestException) {
 				completeSuccess = false;
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericException(e);

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2858,7 +2858,7 @@ namespace ArchiSteamFarm {
 
 			// It'd also make sense to run all of this in parallel, but it seems that Steam has a lot of problems with inventory-related parallel requests | https://steamcommunity.com/groups/ascfarm/discussions/1/3559414588264550284/
 			try {
-				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID).Where(x => x.Type == Steam.Asset.EType.BoosterPack).ConfigureAwait(false)) {
+				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID).Where(item => item.Type == Steam.Asset.EType.BoosterPack).ConfigureAwait(false)) {
 					if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
 						completeSuccess = false;
 					}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2856,10 +2856,15 @@ namespace ArchiSteamFarm {
 			bool completeSuccess = true;
 
 			// It'd also make sense to run all of this in parallel, but it seems that Steam has a lot of problems with inventory-related parallel requests | https://steamcommunity.com/groups/ascfarm/discussions/1/3559414588264550284/
-			await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, wantedTypes: new HashSet<Steam.Asset.EType> { Steam.Asset.EType.BoosterPack }).ConfigureAwait(false)) {
-				if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
-					completeSuccess = false;
+			try {
+				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, wantedTypes: new HashSet<Steam.Asset.EType> { Steam.Asset.EType.BoosterPack }).ConfigureAwait(false)) {
+					if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
+						completeSuccess = false;
+					}
 				}
+			} catch (Exception e) {
+				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+				completeSuccess = false;
 			}
 
 			return FormatBotResponse(completeSuccess ? Strings.Success : Strings.Done);

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2858,7 +2858,7 @@ namespace ArchiSteamFarm {
 
 			// It'd also make sense to run all of this in parallel, but it seems that Steam has a lot of problems with inventory-related parallel requests | https://steamcommunity.com/groups/ascfarm/discussions/1/3559414588264550284/
 			try {
-				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(x => x.Type == Steam.Asset.EType.BoosterPack).ConfigureAwait(false)) {
+				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID).Where(x => x.Type == Steam.Asset.EType.BoosterPack).ConfigureAwait(false)) {
 					if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
 						completeSuccess = false;
 					}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -2862,8 +2863,11 @@ namespace ArchiSteamFarm {
 						completeSuccess = false;
 					}
 				}
+			} catch (IOException) {
+				completeSuccess = false;
 			} catch (Exception e) {
-				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+				Bot.ArchiLogger.LogGenericWarningException(e);
+
 				completeSuccess = false;
 			}
 

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2852,17 +2852,11 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotNotConnected);
 			}
 
-			HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventory(Bot.SteamID, wantedTypes: new HashSet<Steam.Asset.EType> { Steam.Asset.EType.BoosterPack }).ConfigureAwait(false);
-
-			if ((inventory == null) || (inventory.Count == 0)) {
-				return FormatBotResponse(string.Format(Strings.ErrorIsEmpty, nameof(inventory)));
-			}
-
 			// It'd make sense here to actually check return code of ArchiWebHandler.UnpackBooster(), but it lies most of the time | https://github.com/JustArchi/ArchiSteamFarm/issues/704
 			bool completeSuccess = true;
 
 			// It'd also make sense to run all of this in parallel, but it seems that Steam has a lot of problems with inventory-related parallel requests | https://steamcommunity.com/groups/ascfarm/discussions/1/3559414588264550284/
-			foreach (Steam.Asset item in inventory) {
+			await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID, wantedTypes: new HashSet<Steam.Asset.EType> { Steam.Asset.EType.BoosterPack }).ConfigureAwait(false)) {
 				if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
 					completeSuccess = false;
 				}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2745,7 +2745,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotSendingTradeToYourself);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -2857,18 +2857,10 @@ namespace ArchiSteamFarm {
 
 			// It'd also make sense to run all of this in parallel, but it seems that Steam has a lot of problems with inventory-related parallel requests | https://steamcommunity.com/groups/ascfarm/discussions/1/3559414588264550284/
 			try {
-				HashSet<ulong> unpackedAssets = new HashSet<ulong>();
-
 				await foreach (Steam.Asset item in Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(x => x.Type == Steam.Asset.EType.BoosterPack).ConfigureAwait(false)) {
-					if (unpackedAssets.Contains(item.AssetID)) {
-						continue;
-					}
-
 					if (!await Bot.ArchiWebHandler.UnpackBooster(item.RealAppID, item.AssetID).ConfigureAwait(false)) {
 						completeSuccess = false;
 					}
-
-					unpackedAssets.Add(item.AssetID);
 				}
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));

--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -654,7 +654,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(string.Format(Strings.ErrorIsInvalid, nameof(contextID)));
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(appID, contextID).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(appID, contextID).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -799,7 +799,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.TargetBotNotConnected);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(appID, contextID, targetBot.SteamID).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(appID, contextID, targetBot.SteamID).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -1504,7 +1504,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(string.Format(Strings.ErrorIsEmpty, nameof(Bot.BotConfig.LootableTypes)));
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -1565,7 +1565,7 @@ namespace ArchiSteamFarm {
 				realAppIDs.Add(appID);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -2692,7 +2692,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotSendingTradeToYourself);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type)).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type)).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}
@@ -2745,7 +2745,7 @@ namespace ArchiSteamFarm {
 				return FormatBotResponse(Strings.BotSendingTradeToYourself);
 			}
 
-			(bool success, string message) = await Bot.Actions.SendTradeOfferAsync(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
+			(bool success, string message) = await Bot.Actions.SendInventory(targetSteamID: targetBot.SteamID, filterFunction: item => Bot.BotConfig.TransferableTypes.Contains(item.Type) && (exclude ^ realAppIDs.Contains(item.RealAppID))).ConfigureAwait(false);
 
 			return FormatBotResponse(success ? message : string.Format(Strings.WarningFailedWithError, message));
 		}

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -185,7 +185,7 @@ namespace ArchiSteamFarm {
 
 					return;
 				} catch (Exception e) {
-					Bot.ArchiLogger.LogGenericWarningException(e);
+					Bot.ArchiLogger.LogGenericException(e);
 
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
 					ShouldSendHeartBeats = false;
@@ -366,7 +366,7 @@ namespace ArchiSteamFarm {
 			} catch (IOException) {
 				return false;
 			} catch (Exception e) {
-				Bot.ArchiLogger.LogGenericWarningException(e);
+				Bot.ArchiLogger.LogGenericException(e);
 
 				return false;
 			}
@@ -424,7 +424,7 @@ namespace ArchiSteamFarm {
 				} catch (IOException) {
 					continue;
 				} catch (Exception e) {
-					Bot.ArchiLogger.LogGenericWarningException(e);
+					Bot.ArchiLogger.LogGenericException(e);
 
 					continue;
 				}

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -174,7 +174,7 @@ namespace ArchiSteamFarm {
 					return;
 				}
 
-				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventory(tradable: true, wantedTypes: acceptedMatchableTypes).ConfigureAwait(false);
+				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 
 				if (inventory == null) {
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
@@ -349,7 +349,7 @@ namespace ArchiSteamFarm {
 				return false;
 			}
 
-			HashSet<Steam.Asset> ourInventory = await Bot.ArchiWebHandler.GetInventory(wantedTypes: acceptedMatchableTypes).ConfigureAwait(false);
+			HashSet<Steam.Asset> ourInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 
 			if ((ourInventory == null) || (ourInventory.Count == 0)) {
 				Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(ourInventory)));
@@ -397,7 +397,7 @@ namespace ArchiSteamFarm {
 
 				Bot.ArchiLogger.LogGenericTrace(listedUser.SteamID + "...");
 
-				HashSet<Steam.Asset> theirInventory = await Bot.ArchiWebHandler.GetInventory(listedUser.SteamID, tradable: listedUser.MatchEverything ? true : (bool?) null, wantedSets: wantedSets).ConfigureAwait(false);
+				HashSet<Steam.Asset> theirInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 
 				if ((theirInventory == null) || (theirInventory.Count == 0)) {
 					Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(theirInventory)));

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -174,15 +174,13 @@ namespace ArchiSteamFarm {
 					return;
 				}
 
-				HashSet<Steam.Asset> inventory = null;
+				HashSet<Steam.Asset> inventory;
 
 				try {
 					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 				} catch (Exception e) {
 					Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
-				}
 
-				if (inventory == null) {
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
 					ShouldSendHeartBeats = false;
 
@@ -361,9 +359,11 @@ namespace ArchiSteamFarm {
 				ourInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+
+				return false;
 			}
 
-			if ((ourInventory == null) || (ourInventory.Count == 0)) {
+			if (ourInventory.Count == 0) {
 				Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(ourInventory)));
 
 				return false;
@@ -409,15 +409,17 @@ namespace ArchiSteamFarm {
 
 				Bot.ArchiLogger.LogGenericTrace(listedUser.SteamID + "...");
 
-				HashSet<Steam.Asset> theirInventory = null;
+				HashSet<Steam.Asset> theirInventory;
 
 				try {
 					theirInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 				} catch (Exception e) {
 					Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+
+					continue;
 				}
 
-				if ((theirInventory == null) || (theirInventory.Count == 0)) {
+				if (theirInventory.Count == 0) {
 					Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(theirInventory)));
 
 					continue;

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -23,8 +23,8 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Json;
@@ -179,7 +179,7 @@ namespace ArchiSteamFarm {
 
 				try {
 					inventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
-				} catch (IOException) {
+				} catch (HttpRequestException) {
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
 					ShouldSendHeartBeats = false;
 
@@ -363,7 +363,7 @@ namespace ArchiSteamFarm {
 
 			try {
 				ourInventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
-			} catch (IOException) {
+			} catch (HttpRequestException) {
 				return false;
 			} catch (Exception e) {
 				Bot.ArchiLogger.LogGenericException(e);
@@ -421,7 +421,7 @@ namespace ArchiSteamFarm {
 
 				try {
 					theirInventory = await Bot.ArchiWebHandler.GetInventoryAsync(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
-				} catch (IOException) {
+				} catch (HttpRequestException) {
 					continue;
 				} catch (Exception e) {
 					Bot.ArchiLogger.LogGenericException(e);

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -178,7 +178,7 @@ namespace ArchiSteamFarm {
 				HashSet<Steam.Asset> inventory;
 
 				try {
-					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+					inventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 				} catch (IOException) {
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
 					ShouldSendHeartBeats = false;
@@ -362,7 +362,7 @@ namespace ArchiSteamFarm {
 			HashSet<Steam.Asset> ourInventory;
 
 			try {
-				ourInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+				ourInventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
 			} catch (IOException) {
 				return false;
 			} catch (Exception e) {
@@ -420,7 +420,7 @@ namespace ArchiSteamFarm {
 				HashSet<Steam.Asset> theirInventory;
 
 				try {
-					theirInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+					theirInventory = await Bot.ArchiWebHandler.GetInventoryAsync(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 				} catch (IOException) {
 					continue;
 				} catch (Exception e) {

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -174,7 +174,13 @@ namespace ArchiSteamFarm {
 					return;
 				}
 
-				HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+				HashSet<Steam.Asset> inventory = null;
+
+				try {
+					inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => item.Tradable && acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+				} catch (Exception e) {
+					Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+				}
 
 				if (inventory == null) {
 					// This is actually inventory failure, so we'll stop sending heartbeats but not record it as valid check
@@ -349,7 +355,13 @@ namespace ArchiSteamFarm {
 				return false;
 			}
 
-			HashSet<Steam.Asset> ourInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+			HashSet<Steam.Asset> ourInventory = null;
+
+			try {
+				ourInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+			} catch (Exception e) {
+				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+			}
 
 			if ((ourInventory == null) || (ourInventory.Count == 0)) {
 				Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(ourInventory)));
@@ -397,7 +409,13 @@ namespace ArchiSteamFarm {
 
 				Bot.ArchiLogger.LogGenericTrace(listedUser.SteamID + "...");
 
-				HashSet<Steam.Asset> theirInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+				HashSet<Steam.Asset> theirInventory = null;
+
+				try {
+					theirInventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(listedUser.SteamID).Where(item => (!listedUser.MatchEverything || item.Tradable) && wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+				} catch (Exception e) {
+					Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+				}
 
 				if ((theirInventory == null) || (theirInventory.Count == 0)) {
 					Bot.ArchiLogger.LogGenericTrace(string.Format(Strings.ErrorIsEmpty, nameof(theirInventory)));

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -611,7 +611,7 @@ namespace ArchiSteamFarm {
 			HashSet<Steam.Asset> inventory;
 
 			try {
-				inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+				inventory = await Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 			} catch (IOException) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
 				return ParseTradeResult.EResult.TryAgain;

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -607,7 +607,13 @@ namespace ArchiSteamFarm {
 			}
 
 			// Now check if it's worth for us to do the trade
-			HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+			HashSet<Steam.Asset> inventory = null;
+
+			try {
+				inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+			} catch (Exception e) {
+				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+			}
 
 			if ((inventory == null) || (inventory.Count == 0)) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -22,8 +22,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Collections;
@@ -612,7 +612,7 @@ namespace ArchiSteamFarm {
 
 			try {
 				inventory = await Bot.ArchiWebHandler.GetInventoryAsync(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
-			} catch (IOException) {
+			} catch (HttpRequestException) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
 				return ParseTradeResult.EResult.TryAgain;
 			} catch (Exception e) {

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -607,7 +607,7 @@ namespace ArchiSteamFarm {
 			}
 
 			// Now check if it's worth for us to do the trade
-			HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventory(Bot.SteamID, wantedSets: wantedSets).ConfigureAwait(false);
+			HashSet<Steam.Asset> inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 
 			if ((inventory == null) || (inventory.Count == 0)) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -360,7 +360,7 @@ namespace ArchiSteamFarm {
 				}
 
 				if (lootableTypesReceived && Bot.BotConfig.SendOnFarmingFinished && (Bot.BotConfig.LootableTypes.Count > 0)) {
-					await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
+					await Bot.Actions.SendInventory(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 				}
 			} finally {
 				TradesSemaphore.Release();

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -611,9 +612,12 @@ namespace ArchiSteamFarm {
 
 			try {
 				inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
+			} catch (IOException) {
+				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
+				return ParseTradeResult.EResult.TryAgain;
 			} catch (Exception e) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
-				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+				Bot.ArchiLogger.LogGenericWarningException(e);
 
 				return ParseTradeResult.EResult.TryAgain;
 			}

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -617,7 +617,7 @@ namespace ArchiSteamFarm {
 				return ParseTradeResult.EResult.TryAgain;
 			} catch (Exception e) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
-				Bot.ArchiLogger.LogGenericWarningException(e);
+				Bot.ArchiLogger.LogGenericException(e);
 
 				return ParseTradeResult.EResult.TryAgain;
 			}

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -607,15 +607,18 @@ namespace ArchiSteamFarm {
 			}
 
 			// Now check if it's worth for us to do the trade
-			HashSet<Steam.Asset> inventory = null;
+			HashSet<Steam.Asset> inventory;
 
 			try {
 				inventory = await Bot.ArchiWebHandler.GetInventoryEnumerable(Bot.SteamID).Where(item => wantedSets.Contains((item.RealAppID, item.Type, item.Rarity))).ToHashSetAsync().ConfigureAwait(false);
 			} catch (Exception e) {
+				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.WarningFailedWithError, e.Message));
+
+				return ParseTradeResult.EResult.TryAgain;
 			}
 
-			if ((inventory == null) || (inventory.Count == 0)) {
+			if (inventory.Count == 0) {
 				// If we can't check our inventory when not using MatchEverything, this is a temporary failure, try again later
 				Bot.ArchiLogger.LogGenericWarning(string.Format(Strings.ErrorIsEmpty, nameof(inventory)));
 

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -360,7 +360,7 @@ namespace ArchiSteamFarm {
 				}
 
 				if (lootableTypesReceived && Bot.BotConfig.SendOnFarmingFinished && (Bot.BotConfig.LootableTypes.Count > 0)) {
-					await Bot.Actions.SendTradeOffer(wantedTypes: Bot.BotConfig.LootableTypes).ConfigureAwait(false);
+					await Bot.Actions.SendTradeOfferAsync(filterFunction: item => Bot.BotConfig.LootableTypes.Contains(item.Type)).ConfigureAwait(false);
 				}
 			} finally {
 				TradesSemaphore.Release();


### PR DESCRIPTION
Allows to use the new IAsyncEnumerable type for getting items continuously, when we don't care about full inventory load (e.g. unpacking boosters).
Exceptions are necessary for breaking the control flow in case if we have to load full inventory and we can't just ignore errors (e.g. matching items).