### PR TITLE
Add additional properties to Asset

### DIFF
--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -203,7 +203,7 @@ namespace ArchiSteamFarm {
 						throw new NotSupportedException(string.Format(Strings.ErrorObjectIsNull, nameof(response.Assets) + " || " + nameof(response.Descriptions)));
 					}
 
-					Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)> descriptions = new Dictionary<(ulong ClassID, ulong InstanceID), (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity)>();
+					Dictionary<(ulong ClassID, ulong InstanceID), Steam.InventoryResponse.Description> descriptions = new Dictionary<(ulong ClassID, ulong InstanceID), Steam.InventoryResponse.Description>();
 
 					foreach (Steam.InventoryResponse.Description description in response.Descriptions.Where(description => description != null)) {
 						if (description.ClassID == 0) {
@@ -216,11 +216,11 @@ namespace ArchiSteamFarm {
 							continue;
 						}
 
-						descriptions[key] = (description.Marketable, description.Tradable, description.RealAppID, description.Type, description.Rarity);
+						descriptions[key] = description;
 					}
 
 					foreach (Steam.Asset asset in response.Assets.Where(asset => asset != null)) {
-						if (!descriptions.TryGetValue((asset.ClassID, asset.InstanceID), out (bool Marketable, bool Tradable, uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) description) || assetIDs.Contains(asset.AssetID)) {
+						if (!descriptions.TryGetValue((asset.ClassID, asset.InstanceID), out Steam.InventoryResponse.Description description) || assetIDs.Contains(asset.AssetID)) {
 							continue;
 						}
 
@@ -229,6 +229,8 @@ namespace ArchiSteamFarm {
 						asset.RealAppID = description.RealAppID;
 						asset.Type = description.Type;
 						asset.Rarity = description.Rarity;
+						asset.AdditionalProperties = description.AdditionalProperties;
+
 						assetIDs.Add(asset.AssetID);
 
 						yield return asset;

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1521,8 +1521,6 @@ namespace ArchiSteamFarm {
 
 						parsedTags.Add(new Steam.InventoryResponse.Description.Tag(identifier, value));
 					}
-
-					(type, rarity, realAppID) = Steam.InventoryResponse.Description.InterpretTags(parsedTags);
 				}
 
 				descriptions[key] = (marketable, realAppID, type, rarity);

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -77,7 +77,7 @@ namespace ArchiSteamFarm.Json {
 			[PublicAPI]
 			public EType Type { get; internal set; }
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "amount", Required = Required.Always)]
 			[JetBrains.Annotations.NotNull]
 			private string AmountText {
@@ -99,9 +99,9 @@ namespace ArchiSteamFarm.Json {
 					Amount = amount;
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
-			#pragma warning disable IDE0052
+#pragma warning disable IDE0052
 			[JsonProperty(PropertyName = "assetid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string AssetIDText {
@@ -123,9 +123,9 @@ namespace ArchiSteamFarm.Json {
 					AssetID = assetID;
 				}
 			}
-			#pragma warning restore IDE0052
+#pragma warning restore IDE0052
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "classid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string ClassIDText {
@@ -143,9 +143,9 @@ namespace ArchiSteamFarm.Json {
 					ClassID = classID;
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "contextid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string ContextIDText {
@@ -167,17 +167,17 @@ namespace ArchiSteamFarm.Json {
 					ContextID = contextID;
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "id", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string IDText {
 				set => AssetIDText = value;
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "instanceid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string InstanceIDText {
@@ -195,7 +195,7 @@ namespace ArchiSteamFarm.Json {
 					InstanceID = instanceID;
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
 			// Constructed from trades being received or plugins
 			public Asset(uint appID, ulong contextID, ulong classID, ulong instanceID, uint amount, bool marketable = true, uint realAppID = 0, EType type = EType.Unknown, ERarity rarity = ERarity.Unknown) {
@@ -259,7 +259,7 @@ namespace ArchiSteamFarm.Json {
 			internal ulong TradeOfferID { get; private set; }
 			internal EType Type { get; private set; }
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "html", Required = Required.DisallowNull)]
 			private string HTML {
 				set {
@@ -329,7 +329,7 @@ namespace ArchiSteamFarm.Json {
 					}
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			private ConfirmationDetails() { }
@@ -362,7 +362,7 @@ namespace ArchiSteamFarm.Json {
 			[PublicAPI]
 			public bool Success { get; private set; }
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "success", Required = Required.Always)]
 			private byte SuccessNumber {
 				set {
@@ -382,7 +382,7 @@ namespace ArchiSteamFarm.Json {
 					}
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			protected NumberResponse() { }
@@ -448,7 +448,7 @@ namespace ArchiSteamFarm.Json {
 			internal ulong LastAssetID { get; private set; }
 			internal bool MoreItems { get; private set; }
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "last_assetid", Required = Required.DisallowNull)]
 			private string LastAssetIDText {
 				set {
@@ -467,24 +467,24 @@ namespace ArchiSteamFarm.Json {
 					LastAssetID = lastAssetID;
 				}
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
-			#pragma warning disable IDE0051
+#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "more_items", Required = Required.DisallowNull)]
 			private byte MoreItemsNumber {
 				set => MoreItems = value > 0;
 			}
-			#pragma warning restore IDE0051
+#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			private InventoryResponse() { }
 
 			internal sealed class Description {
+				[JsonExtensionData]
+				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
+
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;
-
-				[JsonExtensionData]
-				internal ImmutableDictionary<string, JToken> AdditionalProperties;
 
 				internal ulong ClassID { get; private set; }
 				internal ulong InstanceID { get; private set; }
@@ -517,7 +517,6 @@ namespace ArchiSteamFarm.Json {
 									}
 
 									break;
-
 							}
 						}
 

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -42,7 +42,7 @@ namespace ArchiSteamFarm.Json {
 			public const ulong SteamCommunityContextID = 6;
 
 			[PublicAPI]
-			public Dictionary<string, JToken> AdditionalProperties { get; internal set; }
+			public ImmutableDictionary<string, JToken> AdditionalProperties { get; internal set; }
 
 			[PublicAPI]
 			public uint Amount { get; internal set; }
@@ -481,7 +481,7 @@ namespace ArchiSteamFarm.Json {
 
 			internal sealed class Description {
 				[JsonExtensionData]
-				internal Dictionary<string, JToken> AdditionalProperties;
+				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
 
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -482,7 +482,7 @@ namespace ArchiSteamFarm.Json {
 			internal sealed class Description {
 				[JsonExtensionData]
 #pragma warning disable 649
-				internal ImmutableDictionary<string, JToken> AdditionalProperties;
+				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
 #pragma warning restore 649
 
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -77,7 +77,7 @@ namespace ArchiSteamFarm.Json {
 			[PublicAPI]
 			public EType Type { get; internal set; }
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "amount", Required = Required.Always)]
 			[JetBrains.Annotations.NotNull]
 			private string AmountText {
@@ -99,9 +99,9 @@ namespace ArchiSteamFarm.Json {
 					Amount = amount;
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
-#pragma warning disable IDE0052
+			#pragma warning disable IDE0052
 			[JsonProperty(PropertyName = "assetid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string AssetIDText {
@@ -123,9 +123,9 @@ namespace ArchiSteamFarm.Json {
 					AssetID = assetID;
 				}
 			}
-#pragma warning restore IDE0052
+			#pragma warning restore IDE0052
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "classid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string ClassIDText {
@@ -143,9 +143,9 @@ namespace ArchiSteamFarm.Json {
 					ClassID = classID;
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "contextid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string ContextIDText {
@@ -167,17 +167,17 @@ namespace ArchiSteamFarm.Json {
 					ContextID = contextID;
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "id", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string IDText {
 				set => AssetIDText = value;
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "instanceid", Required = Required.DisallowNull)]
 			[JetBrains.Annotations.NotNull]
 			private string InstanceIDText {
@@ -195,7 +195,7 @@ namespace ArchiSteamFarm.Json {
 					InstanceID = instanceID;
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
 			// Constructed from trades being received or plugins
 			public Asset(uint appID, ulong contextID, ulong classID, ulong instanceID, uint amount, bool marketable = true, uint realAppID = 0, EType type = EType.Unknown, ERarity rarity = ERarity.Unknown) {
@@ -259,7 +259,7 @@ namespace ArchiSteamFarm.Json {
 			internal ulong TradeOfferID { get; private set; }
 			internal EType Type { get; private set; }
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "html", Required = Required.DisallowNull)]
 			private string HTML {
 				set {
@@ -329,7 +329,7 @@ namespace ArchiSteamFarm.Json {
 					}
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			private ConfirmationDetails() { }
@@ -362,7 +362,7 @@ namespace ArchiSteamFarm.Json {
 			[PublicAPI]
 			public bool Success { get; private set; }
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "success", Required = Required.Always)]
 			private byte SuccessNumber {
 				set {
@@ -382,7 +382,7 @@ namespace ArchiSteamFarm.Json {
 					}
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			protected NumberResponse() { }
@@ -448,7 +448,7 @@ namespace ArchiSteamFarm.Json {
 			internal ulong LastAssetID { get; private set; }
 			internal bool MoreItems { get; private set; }
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "last_assetid", Required = Required.DisallowNull)]
 			private string LastAssetIDText {
 				set {
@@ -467,32 +467,50 @@ namespace ArchiSteamFarm.Json {
 					LastAssetID = lastAssetID;
 				}
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
-#pragma warning disable IDE0051
+			#pragma warning disable IDE0051
 			[JsonProperty(PropertyName = "more_items", Required = Required.DisallowNull)]
 			private byte MoreItemsNumber {
 				set => MoreItems = value > 0;
 			}
-#pragma warning restore IDE0051
+			#pragma warning restore IDE0051
 
 			[JsonConstructor]
 			private InventoryResponse() { }
 
 			internal sealed class Description {
-				[JsonExtensionData]
-				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
-
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;
+
+				[JsonExtensionData]
+				internal ImmutableDictionary<string, JToken> AdditionalProperties;
 
 				internal ulong ClassID { get; private set; }
 				internal ulong InstanceID { get; private set; }
 				internal bool Marketable { get; private set; }
 				internal Asset.ERarity Rarity { get; private set; }
 				internal uint RealAppID { get; private set; }
+
+				[JsonProperty(PropertyName = "tags", Required = Required.DisallowNull)]
+				internal ImmutableHashSet<Tag> Tags {
+					set {
+						if ((value == null) || (value.Count == 0)) {
+							ASF.ArchiLogger.LogNullError(nameof(value));
+
+							return;
+						}
+
+						(Type, Rarity, RealAppID) = InterpretTags(value);
+						BackingTags = value;
+					}
+					get => BackingTags;
+				}
+
 				internal bool Tradable { get; private set; }
 				internal Asset.EType Type { get; private set; }
+
+				private ImmutableHashSet<Tag> BackingTags;
 
 #pragma warning disable IDE0051
 				[JsonProperty(PropertyName = "classid", Required = Required.Always)]
@@ -538,21 +556,6 @@ namespace ArchiSteamFarm.Json {
 				[JsonProperty(PropertyName = "marketable", Required = Required.Always)]
 				private byte MarketableNumber {
 					set => Marketable = value > 0;
-				}
-#pragma warning restore IDE0051
-
-#pragma warning disable IDE0051
-				[JsonProperty(PropertyName = "tags", Required = Required.DisallowNull)]
-				private ImmutableHashSet<Tag> Tags {
-					set {
-						if ((value == null) || (value.Count == 0)) {
-							ASF.ArchiLogger.LogNullError(nameof(value));
-
-							return;
-						}
-
-						(Type, Rarity, RealAppID) = InterpretTags(value);
-					}
 				}
 #pragma warning restore IDE0051
 

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -480,8 +480,8 @@ namespace ArchiSteamFarm.Json {
 			private InventoryResponse() { }
 
 			internal sealed class Description {
-				[JsonExtensionData]
 #pragma warning disable 649
+				[JsonExtensionData]
 				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
 #pragma warning restore 649
 

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -28,6 +28,7 @@ using ArchiSteamFarm.Localization;
 using HtmlAgilityPack;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using SteamKit2;
 
 namespace ArchiSteamFarm.Json {
@@ -39,6 +40,9 @@ namespace ArchiSteamFarm.Json {
 
 			[PublicAPI]
 			public const ulong SteamCommunityContextID = 6;
+
+			[PublicAPI]
+			public Dictionary<string, JToken> AdditionalProperties { get; internal set; }
 
 			[PublicAPI]
 			public uint Amount { get; internal set; }
@@ -476,6 +480,9 @@ namespace ArchiSteamFarm.Json {
 			private InventoryResponse() { }
 
 			internal sealed class Description {
+				[JsonExtensionData]
+				internal Dictionary<string, JToken> AdditionalProperties;
+
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;
 

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -481,7 +481,7 @@ namespace ArchiSteamFarm.Json {
 
 			internal sealed class Description {
 				[JsonExtensionData]
-				internal readonly ImmutableDictionary<string, JToken> AdditionalProperties;
+				internal ImmutableDictionary<string, JToken> AdditionalProperties;
 
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;
@@ -492,24 +492,16 @@ namespace ArchiSteamFarm.Json {
 
 				internal Asset.ERarity Rarity {
 					get {
-						Asset.ERarity rarity = Asset.ERarity.Unknown;
-
 						foreach (Tag tag in Tags) {
 							switch (tag.Identifier) {
 								case "droprate":
 									switch (tag.Value) {
 										case "droprate_0":
-											rarity = Asset.ERarity.Common;
-
-											break;
+											return Asset.ERarity.Common;
 										case "droprate_1":
-											rarity = Asset.ERarity.Uncommon;
-
-											break;
+											return Asset.ERarity.Uncommon;
 										case "droprate_2":
-											rarity = Asset.ERarity.Rare;
-
-											break;
+											return Asset.ERarity.Rare;
 										default:
 											ASF.ArchiLogger.LogGenericError(string.Format(Strings.WarningUnknownValuePleaseReport, nameof(tag.Value), tag.Value));
 
@@ -520,14 +512,12 @@ namespace ArchiSteamFarm.Json {
 							}
 						}
 
-						return rarity;
+						return Asset.ERarity.Unknown;
 					}
 				}
 
 				internal uint RealAppID {
 					get {
-						uint realAppID = 0;
-
 						foreach (Tag tag in Tags) {
 							switch (tag.Identifier) {
 								case "Game":
@@ -545,18 +535,16 @@ namespace ArchiSteamFarm.Json {
 										break;
 									}
 
-									realAppID = appID;
-
-									break;
+									return appID;
 							}
 						}
 
-						return realAppID;
+						return 0;
 					}
 				}
 
 				[JsonProperty(PropertyName = "tags", Required = Required.DisallowNull)]
-				internal ImmutableHashSet<Tag> Tags;
+				internal readonly ImmutableHashSet<Tag> Tags;
 
 				internal bool Tradable { get; private set; }
 
@@ -569,13 +557,9 @@ namespace ArchiSteamFarm.Json {
 								case "cardborder":
 									switch (tag.Value) {
 										case "cardborder_0":
-											type = Asset.EType.TradingCard;
-
-											break;
+											return Asset.EType.TradingCard;
 										case "cardborder_1":
-											type = Asset.EType.FoilTradingCard;
-
-											break;
+											return Asset.EType.FoilTradingCard;
 										default:
 											ASF.ArchiLogger.LogGenericError(string.Format(Strings.WarningUnknownValuePleaseReport, nameof(tag.Value), tag.Value));
 
@@ -593,45 +577,25 @@ namespace ArchiSteamFarm.Json {
 
 											break;
 										case "item_class_3":
-											type = Asset.EType.ProfileBackground;
-
-											break;
+											return Asset.EType.ProfileBackground;
 										case "item_class_4":
-											type = Asset.EType.Emoticon;
-
-											break;
+											return Asset.EType.Emoticon;
 										case "item_class_5":
-											type = Asset.EType.BoosterPack;
-
-											break;
+											return Asset.EType.BoosterPack;
 										case "item_class_6":
-											type = Asset.EType.Consumable;
-
-											break;
+											return Asset.EType.Consumable;
 										case "item_class_7":
-											type = Asset.EType.SteamGems;
-
-											break;
+											return Asset.EType.SteamGems;
 										case "item_class_8":
-											type = Asset.EType.ProfileModifier;
-
-											break;
+											return Asset.EType.ProfileModifier;
 										case "item_class_10":
-											type = Asset.EType.SaleItem;
-
-											break;
+											return Asset.EType.SaleItem;
 										case "item_class_11":
-											type = Asset.EType.Sticker;
-
-											break;
+											return Asset.EType.Sticker;
 										case "item_class_12":
-											type = Asset.EType.ChatEffect;
-
-											break;
+											return Asset.EType.ChatEffect;
 										case "item_class_13":
-											type = Asset.EType.MiniProfileBackground;
-
-											break;
+											return Asset.EType.MiniProfileBackground;
 										default:
 											ASF.ArchiLogger.LogGenericError(string.Format(Strings.WarningUnknownValuePleaseReport, nameof(tag.Value), tag.Value));
 

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -481,7 +481,9 @@ namespace ArchiSteamFarm.Json {
 
 			internal sealed class Description {
 				[JsonExtensionData]
+#pragma warning disable 649
 				internal ImmutableDictionary<string, JToken> AdditionalProperties;
+#pragma warning restore 649
 
 				[JsonProperty(PropertyName = "appid", Required = Required.Always)]
 				internal readonly uint AppID;


### PR DESCRIPTION
Allows to get other properties from asset description. However, there is a problem with "tags" - ASF already deserializes and process this property, so they will be lost in case of asset from some game (e.g. CSGO tags will be lost). We can store all the tags, but I am unsure if this is the best solution.