### PR TITLE
Use streams for http responses instead of strings where possible, replace HtmlAgilityPack with AngleSharp

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -51,7 +51,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.13.0" />
     <PackageReference Include="AngleSharp.XPath" Version="1.1.6" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -51,11 +51,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="0.13.0" />
+    <PackageReference Include="AngleSharp.XPath" Version="1.1.6" />
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CryptSharpStandard" Version="1.0.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.23" />
     <PackageReference Include="Humanizer" Version="2.7.9" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="Markdig.Signed" Version="0.18.3" />

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1879,7 +1879,8 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			int index = text.IndexOf("g_daysTheirEscrow = ", StringComparison.Ordinal);
+			const string daysTheirVariableName = "g_daysTheirEscrow = ";
+			int index = text.IndexOf(daysTheirVariableName, StringComparison.Ordinal);
 
 			if (index < 0) {
 				Bot.ArchiLogger.LogNullError(nameof(index));
@@ -1887,7 +1888,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			index += "g_daysTheirEscrow = ".Length;
+			index += daysTheirVariableName.Length;
 			text = text.Substring(index);
 
 			index = text.IndexOf(';');

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1734,7 +1734,7 @@ namespace ArchiSteamFarm {
 
 			HashSet<ulong> results = new HashSet<ulong>(htmlNodes.Count);
 
-			foreach (string giftCardIDText in htmlNodes.Select(node => node.GetNodeAttribute("id"))) {
+			foreach (string giftCardIDText in htmlNodes.Select(node => node.GetAttributeValue("id"))) {
 				if (string.IsNullOrEmpty(giftCardIDText)) {
 					Bot.ArchiLogger.LogNullError(nameof(giftCardIDText));
 
@@ -1783,7 +1783,7 @@ namespace ArchiSteamFarm {
 
 			HashSet<ulong> result = new HashSet<ulong>(htmlNodes.Count);
 
-			foreach (string miniProfile in htmlNodes.Select(htmlNode => htmlNode.GetNodeAttribute("data-miniprofile"))) {
+			foreach (string miniProfile in htmlNodes.Select(htmlNode => htmlNode.GetAttributeValue("data-miniprofile"))) {
 				if (string.IsNullOrEmpty(miniProfile)) {
 					Bot.ArchiLogger.LogNullError(nameof(miniProfile));
 
@@ -2635,7 +2635,7 @@ namespace ArchiSteamFarm {
 				return (false, false);
 			}
 
-			string json = htmlNode.GetNodeAttribute("data-privacysettings");
+			string json = htmlNode.GetAttributeValue("data-privacysettings");
 
 			if (string.IsNullOrEmpty(json)) {
 				Bot.ArchiLogger.LogNullError(nameof(json));

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1309,7 +1309,7 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await UrlPostToHtmlDocumentWithSession(SteamStoreURL, request, data).ConfigureAwait(false);
 
-			return htmlDocument.Body.SelectSingleNode("//div[@class='add_free_content_success_area']") != null;
+			return htmlDocument?.Body.SelectSingleNode("//div[@class='add_free_content_success_area']") != null;
 		}
 
 		internal async Task<bool> ChangePrivacySettings(Steam.UserPrivacy userPrivacy) {

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -31,7 +31,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using AngleSharp.Dom;
-using AngleSharp.XPath;
 using ArchiSteamFarm.Helpers;
 using ArchiSteamFarm.Json;
 using ArchiSteamFarm.Localization;
@@ -1309,7 +1308,7 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await UrlPostToHtmlDocumentWithSession(SteamStoreURL, request, data).ConfigureAwait(false);
 
-			return htmlDocument?.Body.SelectSingleNode("//div[@class='add_free_content_success_area']") != null;
+			return htmlDocument?.SelectSingleNode("//div[@class='add_free_content_success_area']") != null;
 		}
 
 		internal async Task<bool> ChangePrivacySettings(Steam.UserPrivacy userPrivacy) {
@@ -1726,7 +1725,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			List<INode> htmlNodes = response.Body.SelectNodes("//div[@class='pending_gift']/div[starts-with(@id, 'pending_gift_')][count(div[@class='pending_giftcard_leftcol']) > 0]/@id");
+			List<IElement> htmlNodes = response.SelectNodes("//div[@class='pending_gift']/div[starts-with(@id, 'pending_gift_')][count(div[@class='pending_giftcard_leftcol']) > 0]/@id");
 
 			if (htmlNodes.Count == 0) {
 				return new HashSet<ulong>(0);
@@ -1774,7 +1773,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			List<INode> htmlNodes = htmlDocument.Body.SelectNodes("(//table[@class='accountTable'])[2]//a/@data-miniprofile");
+			List<IElement> htmlNodes = htmlDocument.SelectNodes("(//table[@class='accountTable'])[2]//a/@data-miniprofile");
 
 			if (htmlNodes.Count == 0) {
 				// OK, no authorized steamIDs
@@ -1865,7 +1864,7 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await UrlGetToHtmlDocumentWithSession(SteamCommunityURL, request).ConfigureAwait(false);
 
-			INode htmlNode = htmlDocument?.Body.SelectSingleNode("//div[@class='pagecontent']/script");
+			IElement htmlNode = htmlDocument?.SelectSingleNode("//div[@class='pagecontent']/script");
 
 			if (htmlNode == null) {
 				// Trade can be no longer valid
@@ -2315,7 +2314,7 @@ namespace ArchiSteamFarm {
 			const string request = "/dev/apikey?l=english";
 			IDocument htmlDocument = await UrlGetToHtmlDocumentWithSession(SteamCommunityURL, request).ConfigureAwait(false);
 
-			INode titleNode = htmlDocument?.Body.SelectSingleNode("//div[@id='mainContents']/h2");
+			IElement titleNode = htmlDocument?.SelectSingleNode("//div[@id='mainContents']/h2");
 
 			if (titleNode == null) {
 				return (ESteamApiKeyState.Timeout, null);
@@ -2333,7 +2332,7 @@ namespace ArchiSteamFarm {
 				return (ESteamApiKeyState.AccessDenied, null);
 			}
 
-			INode htmlNode = htmlDocument.Body.SelectSingleNode("//div[@id='bodyContents_ex']/p");
+			IElement htmlNode = htmlDocument.SelectSingleNode("//div[@id='bodyContents_ex']/p");
 
 			if (htmlNode == null) {
 				Bot.ArchiLogger.LogNullError(nameof(htmlNode));
@@ -2627,7 +2626,7 @@ namespace ArchiSteamFarm {
 				return (false, false);
 			}
 
-			INode htmlNode = htmlDocument.Body.SelectSingleNode("//div[@data-component='ProfilePrivacySettings']/@data-privacysettings");
+			IElement htmlNode = htmlDocument.SelectSingleNode("//div[@data-component='ProfilePrivacySettings']/@data-privacysettings");
 
 			if (htmlNode == null) {
 				Bot.ArchiLogger.LogNullError(nameof(htmlNode));

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -2656,6 +2656,12 @@ namespace ArchiSteamFarm {
 				return (false, false);
 			}
 
+			if (userPrivacy == null) {
+				Bot.ArchiLogger.LogNullError(nameof(userPrivacy));
+
+				return (false, false);
+			}
+
 			switch (userPrivacy.Settings.Profile) {
 				case Steam.UserPrivacy.PrivacySettings.EPrivacySetting.FriendsOnly:
 				case Steam.UserPrivacy.PrivacySettings.EPrivacySetting.Private:

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1734,7 +1734,7 @@ namespace ArchiSteamFarm {
 
 			HashSet<ulong> results = new HashSet<ulong>(htmlNodes.Count);
 
-			foreach (string giftCardIDText in htmlNodes.Select(node => ((IElement) node).GetAttribute("id"))) {
+			foreach (string giftCardIDText in htmlNodes.Select(node => node.GetNodeAttribute("id"))) {
 				if (string.IsNullOrEmpty(giftCardIDText)) {
 					Bot.ArchiLogger.LogNullError(nameof(giftCardIDText));
 
@@ -1783,7 +1783,7 @@ namespace ArchiSteamFarm {
 
 			HashSet<ulong> result = new HashSet<ulong>(htmlNodes.Count);
 
-			foreach (string miniProfile in htmlNodes.Select(htmlNode => ((IElement) htmlNode).GetAttribute("data-miniprofile"))) {
+			foreach (string miniProfile in htmlNodes.Select(htmlNode => htmlNode.GetNodeAttribute("data-miniprofile"))) {
 				if (string.IsNullOrEmpty(miniProfile)) {
 					Bot.ArchiLogger.LogNullError(nameof(miniProfile));
 
@@ -2635,7 +2635,7 @@ namespace ArchiSteamFarm {
 				return (false, false);
 			}
 
-			string json = ((IElement) htmlNode).GetAttribute("data-privacysettings");
+			string json = htmlNode.GetNodeAttribute("data-privacysettings");
 
 			if (string.IsNullOrEmpty(json)) {
 				Bot.ArchiLogger.LogNullError(nameof(json));

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -391,14 +391,14 @@ namespace ArchiSteamFarm {
 
 			foreach (IElement htmlNode in htmlNodes.Cast<IElement>()) {
 				IElement statsNode = (IElement) htmlNode.SelectSingleNode(".//div[@class='badge_title_stats_content']");
-				IElement appIDNode = (IElement) statsNode?.SelectSingleNode(".//div[@class='card_drop_info_dialog']");
+				INode appIDNode = statsNode?.SelectSingleNode(".//div[@class='card_drop_info_dialog']");
 
 				if (appIDNode == null) {
 					// It's just a badge, nothing more
 					continue;
 				}
 
-				string appIDText = appIDNode.GetAttribute("id");
+				string appIDText = appIDNode.GetNodeAttribute("id");
 
 				if (string.IsNullOrEmpty(appIDText)) {
 					Bot.ArchiLogger.LogNullError(nameof(appIDText));

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -31,7 +31,6 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
-using AngleSharp.XPath;
 using ArchiSteamFarm.Collections;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.Plugins;
@@ -380,18 +379,18 @@ namespace ArchiSteamFarm {
 				return;
 			}
 
-			List<INode> htmlNodes = htmlDocument.Body.SelectNodes("//div[@class='badge_row_inner']");
+			List<IElement> htmlNodes = htmlDocument.SelectNodes("//div[@class='badge_row_inner']");
 
-			if (htmlNodes == null) {
+			if (htmlNodes.Count == 0) {
 				// No eligible badges whatsoever
 				return;
 			}
 
 			HashSet<Task> backgroundTasks = null;
 
-			foreach (IElement htmlNode in htmlNodes.Cast<IElement>()) {
-				IElement statsNode = (IElement) htmlNode.SelectSingleNode(".//div[@class='badge_title_stats_content']");
-				INode appIDNode = statsNode?.SelectSingleNode(".//div[@class='card_drop_info_dialog']");
+			foreach (IElement htmlNode in htmlNodes) {
+				IElement statsNode = htmlNode.SelectSingleElementNode(".//div[@class='badge_title_stats_content']");
+				IElement appIDNode = statsNode?.SelectSingleElementNode(".//div[@class='card_drop_info_dialog']");
 
 				if (appIDNode == null) {
 					// It's just a badge, nothing more
@@ -455,7 +454,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// Cards
-				INode progressNode = statsNode.SelectSingleNode(".//span[@class='progress_info_bold']");
+				IElement progressNode = statsNode.SelectSingleElementNode(".//span[@class='progress_info_bold']");
 
 				if (progressNode == null) {
 					Bot.ArchiLogger.LogNullError(nameof(progressNode));
@@ -494,7 +493,7 @@ namespace ArchiSteamFarm {
 					}
 
 					// To save us on extra work, check cards earned so far first
-					INode cardsEarnedNode = statsNode.SelectSingleNode(".//div[@class='card_drop_info_header']");
+					IElement cardsEarnedNode = statsNode.SelectSingleElementNode(".//div[@class='card_drop_info_header']");
 
 					if (cardsEarnedNode == null) {
 						Bot.ArchiLogger.LogNullError(nameof(cardsEarnedNode));
@@ -539,7 +538,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// Hours
-				INode timeNode = statsNode.SelectSingleNode(".//div[@class='badge_title_stats_playtime']");
+				IElement timeNode = statsNode.SelectSingleElementNode(".//div[@class='badge_title_stats_playtime']");
 
 				if (timeNode == null) {
 					Bot.ArchiLogger.LogNullError(nameof(timeNode));
@@ -568,7 +567,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// Names
-				INode nameNode = statsNode.SelectSingleNode("(.//div[@class='card_drop_info_body'])[last()]");
+				IElement nameNode = statsNode.SelectSingleElementNode("(.//div[@class='card_drop_info_body'])[last()]");
 
 				if (nameNode == null) {
 					Bot.ArchiLogger.LogNullError(nameof(nameNode));
@@ -620,7 +619,7 @@ namespace ArchiSteamFarm {
 				// Levels
 				byte badgeLevel = 0;
 
-				INode levelNode = htmlNode.SelectSingleNode(".//div[@class='badge_info_description']/div[2]");
+				IElement levelNode = htmlNode.SelectSingleElementNode(".//div[@class='badge_info_description']/div[2]");
 
 				if (levelNode != null) {
 					// There is no levelNode if we didn't craft that badge yet (level 0)
@@ -945,7 +944,7 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await Bot.ArchiWebHandler.GetGameCardsPage(appID).ConfigureAwait(false);
 
-			INode progressNode = htmlDocument?.Body.SelectSingleNode("//span[@class='progress_info_bold']");
+			IElement progressNode = htmlDocument?.SelectSingleNode("//span[@class='progress_info_bold']");
 
 			if (progressNode == null) {
 				return null;
@@ -987,7 +986,7 @@ namespace ArchiSteamFarm {
 
 			byte maxPages = 1;
 
-			INode htmlNode = htmlDocument.Body.SelectSingleNode("(//a[@class='pagelink'])[last()]");
+			IElement htmlNode = htmlDocument.SelectSingleNode("(//a[@class='pagelink'])[last()]");
 
 			if (htmlNode != null) {
 				string lastPage = htmlNode.TextContent;

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -398,7 +398,7 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
-				string appIDText = appIDNode.GetNodeAttribute("id");
+				string appIDText = appIDNode.GetAttributeValue("id");
 
 				if (string.IsNullOrEmpty(appIDText)) {
 					Bot.ArchiLogger.LogNullError(nameof(appIDText));

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -306,7 +306,7 @@ namespace ArchiSteamFarm.Json {
 					if (htmlDocument.Body.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
 						Type = EType.Trade;
 
-						IElement tradeOfferNode = (IElement) htmlDocument.Body.SelectSingleNode("//div[@class='tradeoffer']");
+						INode tradeOfferNode = htmlDocument.Body.SelectSingleNode("//div[@class='tradeoffer']");
 
 						if (tradeOfferNode == null) {
 							ASF.ArchiLogger.LogNullError(nameof(tradeOfferNode));
@@ -314,7 +314,7 @@ namespace ArchiSteamFarm.Json {
 							return;
 						}
 
-						string idText = tradeOfferNode.GetAttribute("id");
+						string idText = tradeOfferNode.GetNodeAttribute("id");
 
 						if (string.IsNullOrEmpty(idText)) {
 							ASF.ArchiLogger.LogNullError(nameof(idText));

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -314,7 +314,7 @@ namespace ArchiSteamFarm.Json {
 							return;
 						}
 
-						string idText = tradeOfferNode.GetNodeAttribute("id");
+						string idText = tradeOfferNode.GetAttributeValue("id");
 
 						if (string.IsNullOrEmpty(idText)) {
 							ASF.ArchiLogger.LogNullError(nameof(idText));

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -25,7 +25,6 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using AngleSharp.Dom;
-using AngleSharp.XPath;
 using ArchiSteamFarm.Localization;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -303,10 +302,10 @@ namespace ArchiSteamFarm.Json {
 
 					IDocument htmlDocument = WebBrowser.StringToHtmlDocument(value).Result;
 
-					if (htmlDocument.Body.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
+					if (htmlDocument.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
 						Type = EType.Trade;
 
-						INode tradeOfferNode = htmlDocument.Body.SelectSingleNode("//div[@class='tradeoffer']");
+						IElement tradeOfferNode = htmlDocument.SelectSingleNode("//div[@class='tradeoffer']");
 
 						if (tradeOfferNode == null) {
 							ASF.ArchiLogger.LogNullError(nameof(tradeOfferNode));
@@ -347,7 +346,7 @@ namespace ArchiSteamFarm.Json {
 						}
 
 						TradeOfferID = tradeOfferID;
-					} else if (htmlDocument.Body.SelectSingleNode("//div[@class='mobileconf_listing_prices']") != null) {
+					} else if (htmlDocument.SelectSingleNode("//div[@class='mobileconf_listing_prices']") != null) {
 						Type = EType.Market;
 					} else {
 						// Normally this should be reported, but under some specific circumstances we might actually receive this one

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -24,8 +24,9 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using AngleSharp.Dom;
+using AngleSharp.XPath;
 using ArchiSteamFarm.Localization;
-using HtmlAgilityPack;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -300,18 +301,12 @@ namespace ArchiSteamFarm.Json {
 						return;
 					}
 
-					HtmlDocument htmlDocument = WebBrowser.StringToHtmlDocument(value);
+					IDocument htmlDocument = WebBrowser.StringToHtmlDocument(value).Result;
 
-					if (htmlDocument == null) {
-						ASF.ArchiLogger.LogNullError(nameof(htmlDocument));
-
-						return;
-					}
-
-					if (htmlDocument.DocumentNode.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
+					if (htmlDocument.Body.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
 						Type = EType.Trade;
 
-						HtmlNode tradeOfferNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='tradeoffer']");
+						IElement tradeOfferNode = (IElement) htmlDocument.Body.SelectSingleNode("//div[@class='tradeoffer']");
 
 						if (tradeOfferNode == null) {
 							ASF.ArchiLogger.LogNullError(nameof(tradeOfferNode));
@@ -319,7 +314,7 @@ namespace ArchiSteamFarm.Json {
 							return;
 						}
 
-						string idText = tradeOfferNode.GetAttributeValue("id", null);
+						string idText = tradeOfferNode.GetAttribute("id");
 
 						if (string.IsNullOrEmpty(idText)) {
 							ASF.ArchiLogger.LogNullError(nameof(idText));
@@ -352,7 +347,7 @@ namespace ArchiSteamFarm.Json {
 						}
 
 						TradeOfferID = tradeOfferID;
-					} else if (htmlDocument.DocumentNode.SelectSingleNode("//div[@class='mobileconf_listing_prices']") != null) {
+					} else if (htmlDocument.Body.SelectSingleNode("//div[@class='mobileconf_listing_prices']") != null) {
 						Type = EType.Market;
 					} else {
 						// Normally this should be reported, but under some specific circumstances we might actually receive this one

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -302,6 +302,12 @@ namespace ArchiSteamFarm.Json {
 
 					IDocument htmlDocument = WebBrowser.StringToHtmlDocument(value).Result;
 
+					if (htmlDocument == null) {
+						ASF.ArchiLogger.LogNullError(nameof(htmlDocument));
+
+						return;
+					}
+
 					if (htmlDocument.SelectSingleNode("//div[@class='mobileconf_trade_area']") != null) {
 						Type = EType.Trade;
 

--- a/ArchiSteamFarm/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/MobileAuthenticator.cs
@@ -168,7 +168,7 @@ namespace ArchiSteamFarm {
 			HashSet<Confirmation> result = new HashSet<Confirmation>();
 
 			foreach (INode confirmationNode in confirmationNodes) {
-				string idText = confirmationNode.GetNodeAttribute("data-confid");
+				string idText = confirmationNode.GetAttributeValue("data-confid");
 
 				if (string.IsNullOrEmpty(idText)) {
 					Bot.ArchiLogger.LogNullError(nameof(idText));
@@ -182,7 +182,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string keyText = confirmationNode.GetNodeAttribute("data-key");
+				string keyText = confirmationNode.GetAttributeValue("data-key");
 
 				if (string.IsNullOrEmpty(keyText)) {
 					Bot.ArchiLogger.LogNullError(nameof(keyText));
@@ -196,7 +196,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string typeText = confirmationNode.GetNodeAttribute("data-type");
+				string typeText = confirmationNode.GetAttributeValue("data-type");
 
 				if (string.IsNullOrEmpty(typeText)) {
 					Bot.ArchiLogger.LogNullError(nameof(typeText));

--- a/ArchiSteamFarm/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/MobileAuthenticator.cs
@@ -167,8 +167,8 @@ namespace ArchiSteamFarm {
 
 			HashSet<Confirmation> result = new HashSet<Confirmation>();
 
-			foreach (IElement confirmationNode in confirmationNodes.Cast<IElement>()) {
-				string idText = confirmationNode.GetAttribute("data-confid");
+			foreach (INode confirmationNode in confirmationNodes) {
+				string idText = confirmationNode.GetNodeAttribute("data-confid");
 
 				if (string.IsNullOrEmpty(idText)) {
 					Bot.ArchiLogger.LogNullError(nameof(idText));
@@ -182,7 +182,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string keyText = confirmationNode.GetAttribute("data-key");
+				string keyText = confirmationNode.GetNodeAttribute("data-key");
 
 				if (string.IsNullOrEmpty(keyText)) {
 					Bot.ArchiLogger.LogNullError(nameof(keyText));
@@ -196,7 +196,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string typeText = confirmationNode.GetAttribute("data-type");
+				string typeText = confirmationNode.GetNodeAttribute("data-type");
 
 				if (string.IsNullOrEmpty(typeText)) {
 					Bot.ArchiLogger.LogNullError(nameof(typeText));

--- a/ArchiSteamFarm/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/MobileAuthenticator.cs
@@ -22,13 +22,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
-using AngleSharp.XPath;
 using ArchiSteamFarm.Json;
 using ArchiSteamFarm.Localization;
 using JetBrains.Annotations;
@@ -159,9 +157,9 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await Bot.ArchiWebHandler.GetConfirmations(DeviceID, confirmationHash, time).ConfigureAwait(false);
 
-			List<INode> confirmationNodes = htmlDocument?.Body.SelectNodes("//div[@class='mobileconf_list_entry']");
+			List<IElement> confirmationNodes = htmlDocument?.SelectNodes("//div[@class='mobileconf_list_entry']");
 
-			if (confirmationNodes == null) {
+			if ((confirmationNodes == null) || (confirmationNodes.Count == 0)) {
 				return null;
 			}
 

--- a/ArchiSteamFarm/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/MobileAuthenticator.cs
@@ -157,15 +157,18 @@ namespace ArchiSteamFarm {
 
 			IDocument htmlDocument = await Bot.ArchiWebHandler.GetConfirmations(DeviceID, confirmationHash, time).ConfigureAwait(false);
 
-			List<IElement> confirmationNodes = htmlDocument?.SelectNodes("//div[@class='mobileconf_list_entry']");
-
-			if ((confirmationNodes == null) || (confirmationNodes.Count == 0)) {
+			if (htmlDocument == null) {
 				return null;
 			}
 
 			HashSet<Confirmation> result = new HashSet<Confirmation>();
+			List<IElement> confirmationNodes = htmlDocument.SelectNodes("//div[@class='mobileconf_list_entry']");
 
-			foreach (INode confirmationNode in confirmationNodes) {
+			if (confirmationNodes.Count == 0) {
+				return result;
+			}
+
+			foreach (IElement confirmationNode in confirmationNodes) {
 				string idText = confirmationNode.GetAttributeValue("data-confid");
 
 				if (string.IsNullOrEmpty(idText)) {

--- a/ArchiSteamFarm/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/MobileAuthenticator.cs
@@ -22,13 +22,15 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
+using AngleSharp.XPath;
 using ArchiSteamFarm.Json;
 using ArchiSteamFarm.Localization;
-using HtmlAgilityPack;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
@@ -155,9 +157,9 @@ namespace ArchiSteamFarm {
 
 			await LimitConfirmationsRequestsAsync().ConfigureAwait(false);
 
-			HtmlDocument htmlDocument = await Bot.ArchiWebHandler.GetConfirmations(DeviceID, confirmationHash, time).ConfigureAwait(false);
+			IDocument htmlDocument = await Bot.ArchiWebHandler.GetConfirmations(DeviceID, confirmationHash, time).ConfigureAwait(false);
 
-			HtmlNodeCollection confirmationNodes = htmlDocument?.DocumentNode.SelectNodes("//div[@class='mobileconf_list_entry']");
+			List<INode> confirmationNodes = htmlDocument?.Body.SelectNodes("//div[@class='mobileconf_list_entry']");
 
 			if (confirmationNodes == null) {
 				return null;
@@ -165,8 +167,8 @@ namespace ArchiSteamFarm {
 
 			HashSet<Confirmation> result = new HashSet<Confirmation>();
 
-			foreach (HtmlNode confirmationNode in confirmationNodes) {
-				string idText = confirmationNode.GetAttributeValue("data-confid", null);
+			foreach (IElement confirmationNode in confirmationNodes.Cast<IElement>()) {
+				string idText = confirmationNode.GetAttribute("data-confid");
 
 				if (string.IsNullOrEmpty(idText)) {
 					Bot.ArchiLogger.LogNullError(nameof(idText));
@@ -180,7 +182,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string keyText = confirmationNode.GetAttributeValue("data-key", null);
+				string keyText = confirmationNode.GetAttribute("data-key");
 
 				if (string.IsNullOrEmpty(keyText)) {
 					Bot.ArchiLogger.LogNullError(nameof(keyText));
@@ -194,7 +196,7 @@ namespace ArchiSteamFarm {
 					return null;
 				}
 
-				string typeText = confirmationNode.GetAttributeValue("data-type", null);
+				string typeText = confirmationNode.GetAttribute("data-type");
 
 				if (string.IsNullOrEmpty(typeText)) {
 					Bot.ArchiLogger.LogNullError(nameof(typeText));

--- a/ArchiSteamFarm/SteamSaleEvent.cs
+++ b/ArchiSteamFarm/SteamSaleEvent.cs
@@ -23,8 +23,9 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
+using AngleSharp.XPath;
 using ArchiSteamFarm.Localization;
-using HtmlAgilityPack;
 using JetBrains.Annotations;
 
 namespace ArchiSteamFarm {
@@ -83,20 +84,20 @@ namespace ArchiSteamFarm {
 		}
 
 		private async Task<bool?> IsDiscoveryQueueAvailable() {
-			HtmlDocument htmlDocument = await Bot.ArchiWebHandler.GetDiscoveryQueuePage().ConfigureAwait(false);
+			IDocument htmlDocument = await Bot.ArchiWebHandler.GetDiscoveryQueuePage().ConfigureAwait(false);
 
 			if (htmlDocument == null) {
 				return null;
 			}
 
-			HtmlNode htmlNode = htmlDocument.DocumentNode.SelectSingleNode("//div[@class='subtext']");
+			INode htmlNode = htmlDocument.Body.SelectSingleNode("//div[@class='subtext']");
 
 			if (htmlNode == null) {
 				// Valid, no cards for exploring the queue available
 				return false;
 			}
 
-			string text = htmlNode.InnerText;
+			string text = htmlNode.TextContent;
 
 			if (string.IsNullOrEmpty(text)) {
 				Bot.ArchiLogger.LogNullError(nameof(text));

--- a/ArchiSteamFarm/SteamSaleEvent.cs
+++ b/ArchiSteamFarm/SteamSaleEvent.cs
@@ -24,7 +24,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
-using AngleSharp.XPath;
 using ArchiSteamFarm.Localization;
 using JetBrains.Annotations;
 
@@ -90,7 +89,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			INode htmlNode = htmlDocument.Body.SelectSingleNode("//div[@class='subtext']");
+			IElement htmlNode = htmlDocument.SelectSingleNode("//div[@class='subtext']");
 
 			if (htmlNode == null) {
 				// Valid, no cards for exploring the queue available

--- a/ArchiSteamFarm/Utilities.cs
+++ b/ArchiSteamFarm/Utilities.cs
@@ -61,7 +61,8 @@ namespace ArchiSteamFarm {
 			return args[args.Length - 1];
 		}
 
-		public static string GetNodeAttribute(this INode node, string attributeName) {
+		[PublicAPI]
+		public static string GetAttributeValue(this INode node, string attributeName) {
 			if ((node == null) || string.IsNullOrEmpty(attributeName)) {
 				ASF.ArchiLogger.LogNullError(nameof(node) + " || " + nameof(attributeName));
 

--- a/ArchiSteamFarm/Utilities.cs
+++ b/ArchiSteamFarm/Utilities.cs
@@ -196,9 +196,10 @@ namespace ArchiSteamFarm {
 			return (text.Length % 2 == 0) && text.All(Uri.IsHexDigit);
 		}
 
-		[CanBeNull]
+		[ItemNotNull]
+		[NotNull]
 		[PublicAPI]
-		public static IElement SelectSingleNode([NotNull] this IDocument document, string xpath) => (IElement) document.Body.SelectSingleNode(xpath);
+		public static List<IElement> SelectElementNodes([NotNull] this IElement element, string xpath) => element.SelectNodes(xpath).Cast<IElement>().ToList();
 
 		[ItemNotNull]
 		[NotNull]
@@ -209,10 +210,9 @@ namespace ArchiSteamFarm {
 		[PublicAPI]
 		public static IElement SelectSingleElementNode([NotNull] this IElement element, string xpath) => (IElement) element.SelectSingleNode(xpath);
 
-		[ItemNotNull]
-		[NotNull]
+		[CanBeNull]
 		[PublicAPI]
-		public static List<IElement> SelectElementNodes([NotNull] this IElement element, string xpath) => element.SelectNodes(xpath).Cast<IElement>().ToList();
+		public static IElement SelectSingleNode([NotNull] this IDocument document, string xpath) => (IElement) document.Body.SelectSingleNode(xpath);
 
 		[PublicAPI]
 		public static IEnumerable<T> ToEnumerable<T>(this T item) {

--- a/ArchiSteamFarm/Utilities.cs
+++ b/ArchiSteamFarm/Utilities.cs
@@ -28,6 +28,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
+using AngleSharp.XPath;
 using Humanizer;
 using Humanizer.Localisation;
 using JetBrains.Annotations;
@@ -194,6 +195,24 @@ namespace ArchiSteamFarm {
 
 			return (text.Length % 2 == 0) && text.All(Uri.IsHexDigit);
 		}
+
+		[CanBeNull]
+		[PublicAPI]
+		public static IElement SelectSingleNode([NotNull] this IDocument document, string xpath) => (IElement) document.Body.SelectSingleNode(xpath);
+
+		[ItemNotNull]
+		[NotNull]
+		[PublicAPI]
+		public static List<IElement> SelectNodes([NotNull] this IDocument document, string xpath) => document.Body.SelectNodes(xpath).Cast<IElement>().ToList();
+
+		[CanBeNull]
+		[PublicAPI]
+		public static IElement SelectSingleElementNode([NotNull] this IElement element, string xpath) => (IElement) element.SelectSingleNode(xpath);
+
+		[ItemNotNull]
+		[NotNull]
+		[PublicAPI]
+		public static List<IElement> SelectElementNodes([NotNull] this IElement element, string xpath) => element.SelectNodes(xpath).Cast<IElement>().ToList();
 
 		[PublicAPI]
 		public static IEnumerable<T> ToEnumerable<T>(this T item) {

--- a/ArchiSteamFarm/Utilities.cs
+++ b/ArchiSteamFarm/Utilities.cs
@@ -27,6 +27,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using Humanizer;
 using Humanizer.Localisation;
 using JetBrains.Annotations;
@@ -58,6 +59,16 @@ namespace ArchiSteamFarm {
 			string[] args = text.Split((char[]) null, argsToSkip + 1, StringSplitOptions.RemoveEmptyEntries);
 
 			return args[args.Length - 1];
+		}
+
+		public static string GetNodeAttribute(this INode node, string attributeName) {
+			if ((node == null) || string.IsNullOrEmpty(attributeName)) {
+				ASF.ArchiLogger.LogNullError(nameof(node) + " || " + nameof(attributeName));
+
+				return null;
+			}
+
+			return node is IElement element ? element.GetAttribute(attributeName) : null;
 		}
 
 		[PublicAPI]

--- a/ArchiSteamFarm/WebBrowser.cs
+++ b/ArchiSteamFarm/WebBrowser.cs
@@ -480,7 +480,7 @@ namespace ArchiSteamFarm {
 		}
 
 		[ItemCanBeNull]
-		internal async Task<StreamResponse> UrlGetToStream(string request, string referer = null, ERequestOptions requestOptions = ERequestOptions.None, byte maxTries = MaxTries) {
+		private async Task<StreamResponse> UrlGetToStream(string request, string referer = null, ERequestOptions requestOptions = ERequestOptions.None, byte maxTries = MaxTries) {
 			if (string.IsNullOrEmpty(request) || (maxTries == 0)) {
 				ArchiLogger.LogNullError(nameof(request) + " || " + nameof(maxTries));
 
@@ -490,7 +490,7 @@ namespace ArchiSteamFarm {
 			StreamResponse result = null;
 
 			for (byte i = 0; i < maxTries; i++) {
-				HttpResponseMessage response = await InternalGet(request, referer).ConfigureAwait(false);
+				HttpResponseMessage response = await InternalGet(request, referer, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
 				if (response == null) {
 					continue;
@@ -551,14 +551,14 @@ namespace ArchiSteamFarm {
 			return result;
 		}
 
-		private async Task<HttpResponseMessage> InternalGet(string request, string referer = null, HttpCompletionOption httpCompletionOptions = HttpCompletionOption.ResponseContentRead) {
+		private async Task<HttpResponseMessage> InternalGet(string request, string referer = null, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead) {
 			if (string.IsNullOrEmpty(request)) {
 				ArchiLogger.LogNullError(nameof(request));
 
 				return null;
 			}
 
-			return await InternalRequest(new Uri(request), HttpMethod.Get, null, referer, httpCompletionOptions).ConfigureAwait(false);
+			return await InternalRequest(new Uri(request), HttpMethod.Get, null, referer, httpCompletionOption).ConfigureAwait(false);
 		}
 
 		private async Task<HttpResponseMessage> InternalHead(string request, string referer = null) {
@@ -571,14 +571,14 @@ namespace ArchiSteamFarm {
 			return await InternalRequest(new Uri(request), HttpMethod.Head, null, referer).ConfigureAwait(false);
 		}
 
-		private async Task<HttpResponseMessage> InternalPost(string request, IReadOnlyCollection<KeyValuePair<string, string>> data = null, string referer = null) {
+		private async Task<HttpResponseMessage> InternalPost(string request, IReadOnlyCollection<KeyValuePair<string, string>> data = null, string referer = null, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead) {
 			if (string.IsNullOrEmpty(request)) {
 				ArchiLogger.LogNullError(nameof(request));
 
 				return null;
 			}
 
-			return await InternalRequest(new Uri(request), HttpMethod.Post, data, referer).ConfigureAwait(false);
+			return await InternalRequest(new Uri(request), HttpMethod.Post, data, referer, httpCompletionOption).ConfigureAwait(false);
 		}
 
 		private async Task<HttpResponseMessage> InternalRequest(Uri requestUri, HttpMethod httpMethod, IReadOnlyCollection<KeyValuePair<string, string>> data = null, string referer = null, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead, byte maxRedirections = MaxTries) {
@@ -697,7 +697,7 @@ namespace ArchiSteamFarm {
 			StreamResponse result = null;
 
 			for (byte i = 0; i < maxTries; i++) {
-				HttpResponseMessage response = await InternalPost(request, data, referer).ConfigureAwait(false);
+				HttpResponseMessage response = await InternalPost(request, data, referer, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
 				if (response == null) {
 					continue;

--- a/ArchiSteamFarm/WebBrowser.cs
+++ b/ArchiSteamFarm/WebBrowser.cs
@@ -144,11 +144,11 @@ namespace ArchiSteamFarm {
 				T obj;
 
 				try {
-					using StreamReader sr = new StreamReader(response.Content);
-					using JsonReader reader = new JsonTextReader(sr);
+					using StreamReader streamReader = new StreamReader(response.Content);
+					using JsonReader jsonReader = new JsonTextReader(streamReader);
 					JsonSerializer serializer = new JsonSerializer();
 
-					obj = serializer.Deserialize<T>(reader);
+					obj = serializer.Deserialize<T>(jsonReader);
 				} catch (JsonException e) {
 					ArchiLogger.LogGenericWarningException(e);
 
@@ -343,11 +343,11 @@ namespace ArchiSteamFarm {
 				T obj;
 
 				try {
-					using StreamReader sr = new StreamReader(response.Content);
-					using JsonReader reader = new JsonTextReader(sr);
+					using StreamReader steamReader = new StreamReader(response.Content);
+					using JsonReader jsonReader = new JsonTextReader(steamReader);
 					JsonSerializer serializer = new JsonSerializer();
 
-					obj = serializer.Deserialize<T>(reader);
+					obj = serializer.Deserialize<T>(jsonReader);
 				} catch (JsonException e) {
 					ArchiLogger.LogGenericWarningException(e);
 
@@ -393,6 +393,7 @@ namespace ArchiSteamFarm {
 			}
 
 			IBrowsingContext context = BrowsingContext.New(Configuration.Default.WithXPath());
+
 			return await context.OpenAsync(req => req.Content(html)).ConfigureAwait(false);
 		}
 


### PR DESCRIPTION
Using streams allows to avoid excessive string allocation, and now we're using AngleSharp because HtmlAgilityPack doesn't support asynchronous parsing of stream (also AngleSharp uses much less memory and allocations, and generally is faster).