### PR TITLE
Catch exceptions when creating HtmlDocument from stream

### DIFF
--- a/ArchiSteamFarm/WebBrowser.cs
+++ b/ArchiSteamFarm/WebBrowser.cs
@@ -813,9 +813,9 @@ namespace ArchiSteamFarm {
 
 			internal HtmlDocumentResponse([NotNull] BasicResponse basicResponse) : base(basicResponse) { }
 
-			private HtmlDocumentResponse([NotNull] StreamResponse streamResponse, IDocument document) : base(streamResponse) {
-				if (streamResponse == null) {
-					throw new ArgumentNullException(nameof(streamResponse));
+			private HtmlDocumentResponse([NotNull] StreamResponse streamResponse, [NotNull] IDocument document) : base(streamResponse) {
+				if ((streamResponse == null) || (document == null)) {
+					throw new ArgumentNullException(nameof(streamResponse) + " || " + nameof(document));
 				}
 
 				Content = document;

--- a/ArchiSteamFarm/WebBrowser.cs
+++ b/ArchiSteamFarm/WebBrowser.cs
@@ -751,16 +751,23 @@ namespace ArchiSteamFarm {
 
 			private HtmlDocumentResponse(BasicResponse streamResponse, IDocument document) : base(streamResponse) => Content = document;
 
-			[ItemNotNull]
+			[ItemCanBeNull]
 			internal static async Task<HtmlDocumentResponse> Create([NotNull] StreamResponse streamResponse) {
 				if (streamResponse == null) {
 					throw new ArgumentNullException(nameof(streamResponse));
 				}
 
 				IBrowsingContext context = BrowsingContext.New(Configuration.Default.WithXPath());
-				IDocument document = await context.OpenAsync(req => req.Content(streamResponse.Content, true)).ConfigureAwait(false);
 
-				return new HtmlDocumentResponse(streamResponse, document);
+				try {
+					IDocument document = await context.OpenAsync(req => req.Content(streamResponse.Content, true)).ConfigureAwait(false);
+
+					return new HtmlDocumentResponse(streamResponse, document);
+				} catch (Exception e) {
+					ASF.ArchiLogger.LogGenericWarningException(e);
+
+					return null;
+				}
 			}
 		}
 


### PR DESCRIPTION
This will catch the exceptions occured because of the bad response stream, like these:
```
System.IO.IOException:  Received an unexpected EOF or 0 bytes from the transport stream.
   at System.Net.Security.SslStream.<FillBufferAsync>g__InternalFillBufferAsync|215_0[TReadAdapter](TReadAdapter adap, ValueTask`1 task, Int32 min, Int32 initial)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Net.Http.HttpConnection.ReadAsync(Memory`1 destination)
   at System.Net.Http.HttpConnection.ContentLengthReadStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
   at System.IO.Compression.DeflateStream.FinishReadAsyncMemory(ValueTask`1 readTask, Memory`1 buffer, CancellationToken cancellationToken)
   at AngleSharp.Text.TextSource.ReadIntoBufferAsync(CancellationToken cancellationToken)
   at AngleSharp.Text.TextSource.ExpandBufferAsync(Int64 size, CancellationToken cancellationToken)
   at AngleSharp.Html.Parser.HtmlDomBuilder.ParseAsync(HtmlParserOptions options, CancellationToken cancelToken)
   at AngleSharp.Html.Parser.HtmlParser.ParseAsync(HtmlDocument document, CancellationToken cancel)
   at AngleSharp.Html.Parser.HtmlParser.AngleSharp.Html.Parser.IHtmlParser.ParseDocumentAsync(IDocument document, CancellationToken cancel)
   at AngleSharp.BrowsingContextExtensions.OpenAsync(IBrowsingContext context, Action`1 request, CancellationToken cancel)
   at ArchiSteamFarm.WebBrowser.HtmlDocumentResponse.Create(StreamResponse streamResponse)
   at ArchiSteamFarm.WebBrowser.UrlGetToHtmlDocument(String request, String referer, ERequestOptions requestOptions, Byte maxTries)
   at ArchiSteamFarm.ArchiWebHandler.<>c__DisplayClass42_0.<<UrlGetToHtmlDocumentWithSession>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at ArchiSteamFarm.ArchiWebHandler.WebLimitRequest[T](String service, Func`1 function)
   at ArchiSteamFarm.ArchiWebHandler.UrlGetToHtmlDocumentWithSession(String host, String request, Boolean checkSessionPreemptively, Byte maxTries)
   at ArchiSteamFarm.ArchiWebHandler.GetBadgePage(Byte page)
   at ArchiSteamFarm.CardsFarmer.IsAnythingToFarm()
   at ArchiSteamFarm.CardsFarmer.StartFarming()
   at ArchiSteamFarm.CardsFarmer.OnNewGameAdded()
   at ArchiSteamFarm.Bot.OnLicenseList(LicenseListCallback callback)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__139_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
```