### PR TITLE
Accept HttpContent as data in WebBrowser

### DIFF
--- a/ArchiSteamFarm/WebBrowser.cs
+++ b/ArchiSteamFarm/WebBrowser.cs
@@ -607,6 +607,10 @@ namespace ArchiSteamFarm {
 
 				if (data != null) {
 					switch (data) {
+						case HttpContent content:
+							request.Content = content;
+
+							break;
 						case IReadOnlyCollection<KeyValuePair<string, string>> dictionary:
 							try {
 								request.Content = new FormUrlEncodedContent(dictionary);


### PR DESCRIPTION
This will allow plugins to send any HttpContent, such as MultipartFormDataContent (or any custom payload)