### PR TITLE
Remove workaround for 'Push-AppveyorArtifact'

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -263,8 +263,7 @@ after_test:
             throw "Last command failed."
         }
 
-        # TODO: Change me to Push-AppveyorArtifact once https://github.com/appveyor/ci/issues/2183 is fixed
-        appveyor PushArtifact "out\ASF-$variant.zip" -FileName "ASF-$variant.zip" -DeploymentName "ASF-$variant.zip"
+        Push-AppveyorArtifact "out\ASF-$variant.zip" -FileName "ASF-$variant.zip" -DeploymentName "ASF-$variant.zip"
     }
 
 


### PR DESCRIPTION
It should be no longer needed.