### PR TITLE
Fix permission check in !level

### DIFF
--- a/ArchiSteamFarm/Commands.cs
+++ b/ArchiSteamFarm/Commands.cs
@@ -1368,12 +1368,12 @@ namespace ArchiSteamFarm {
 				throw new ArgumentNullException(nameof(steamID));
 			}
 
-			if (!Bot.IsConnectedAndLoggedOn) {
-				return FormatBotResponse(Strings.BotNotConnected);
-			}
-
 			if (!Bot.HasPermission(steamID, BotConfig.EPermission.Master)) {
 				return null;
+			}
+
+			if (!Bot.IsConnectedAndLoggedOn) {
+				return FormatBotResponse(Strings.BotNotConnected);
 			}
 
 			uint? level = await Bot.ArchiHandler.GetLevel().ConfigureAwait(false);


### PR DESCRIPTION
Check for bot connection happens earlier than permission check, so it's possible to get a response from bot for a user without any permissions. 