### PR TITLE
Implement #852

### DIFF
--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -19,6 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using ArchiSteamFarm.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -121,6 +122,33 @@ namespace ArchiSteamFarm.Tests {
 			Assert.IsTrue(itemsToSend.Count == 5);
 		}
 
-		private static Steam.Asset CreateCard(ulong classID, uint amount = 1) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: 42, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common);
+		[TestMethod]
+		public void SeveralRealAppIDs() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, realAppID: 42),
+				CreateCard(1, realAppID: 43)
+			};
+
+			try {
+				GetItemsForFullBadge(items, 2);
+				Assert.Fail();
+			} catch (ArgumentException) { }
+		}
+
+		[TestMethod]
+		public void SeveralAssetTypes() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(1, type: Steam.Asset.EType.Emoticon)
+			};
+
+			try {
+				GetItemsForFullBadge(items, 42);
+				Assert.Fail();
+			} catch (ArgumentException) { }
+		}
+
+		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: Steam.Asset.ERarity.Common);
 	}
 }

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -302,7 +302,7 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
-		[ExpectedException(typeof(ArgumentException))]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
 		public void TooManyCardsPerSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, AppID1),

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -225,6 +225,60 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		public void MutliRarityAndType() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+
+				CreateCard(1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+
+				CreateCard(1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+
+				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+
+				// for better readability and easier verification when thinking about this test the items that shall be selected for sending are the ones below this comment
+				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(3, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(7, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+
+				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare)
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 3), 3 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 4), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 7), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
 		public void OtherAppIDFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, realAppID: 42),

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -190,6 +190,7 @@ namespace ArchiSteamFarm.Tests {
 
 		private static void AssertResultMatchesExpectation(Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult, IEnumerable<Steam.Asset> itemsToSend) {
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), long> realResult = itemsToSend.GroupBy(asset => (asset.RealAppID, asset.ContextID, asset.ClassID)).ToDictionary(group => group.Key, group => group.Sum(asset => asset.Amount));
+			Assert.AreEqual(expectedResult.Count, realResult.Count);
 			Assert.IsTrue(expectedResult.All(expectation => realResult.TryGetValue(expectation.Key, out long reality) && (expectation.Value == reality)));
 		}
 	}

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -123,19 +123,19 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
 		public void SeveralRealAppIDs() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, realAppID: 42),
 				CreateCard(1, realAppID: 43)
 			};
 
-			try {
-				GetItemsForFullBadge(items, 2);
-				Assert.Fail();
-			} catch (ArgumentException) { }
+			GetItemsForFullBadge(items, 2);
+			Assert.Fail();
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
 		public void SeveralAssetTypes() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, type: Steam.Asset.EType.TradingCard),
@@ -143,10 +143,8 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(1, type: Steam.Asset.EType.Emoticon)
 			};
 
-			try {
-				GetItemsForFullBadge(items, 42);
-				Assert.Fail();
-			} catch (ArgumentException) { }
+			GetItemsForFullBadge(items, 42);
+			Assert.Fail();
 		}
 
 		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: Steam.Asset.ERarity.Common);

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -34,7 +34,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -47,7 +47,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
 				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
@@ -66,7 +66,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
 				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
@@ -84,7 +84,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
 				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
@@ -103,7 +103,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(3)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
 				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
@@ -115,48 +115,182 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
-		public void CardsWithOtherRarity() {
+		public void OtherRarityFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
 				CreateCard(1, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 }
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
-		public void CardsWithOtherType() {
+		public void OtherRarityNoSets() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, rarity: Steam.Asset.ERarity.Rare)
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherRarityOneSet() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, rarity: Steam.Asset.ERarity.Rare)
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherTypeFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, type: Steam.Asset.EType.TradingCard),
 				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
-		public void CardsWithOtherAppID() {
+		public void OtherTypeNoSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, 42),
-				CreateCard(1, (uint) 42 + 1),
+				CreateCard(1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherTypeOneSet() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(2, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(3, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(1, type: Steam.Asset.EType.Unknown),
+				CreateCard(2, type: Steam.Asset.EType.Unknown),
+				CreateCard(3, type: Steam.Asset.EType.Unknown),
+				CreateCard(4, type: Steam.Asset.EType.Unknown)
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 }
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherAppIDFullSets() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, realAppID: 42),
+				CreateCard(1, realAppID: 43),
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
+				items, new Dictionary<uint, byte> {
+					{ 42, 1 },
+					{ 43, 1 }
+				}
+			);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (43, Steam.Asset.SteamCommunityContextID, 1), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherAppIDNoSets() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, realAppID: 42),
+				CreateCard(1, realAppID: 43),
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
+				items, new Dictionary<uint, byte> {
+					{ 42, 2 },
+					{ 43, 2 }
+				}
+			);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
+		}
+
+		[TestMethod]
+		public void OtherAppIDOneSet() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, realAppID: 42),
+				CreateCard(2, realAppID: 42),
+				CreateCard(1, realAppID: 43),
+				CreateCard(2, realAppID: 43),
+				CreateCard(3, realAppID: 43),
+				CreateCard(1, realAppID: 44),
+				CreateCard(2, realAppID: 44),
+				CreateCard(3, realAppID: 44),
+				CreateCard(4, realAppID: 44)
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
+				items, new Dictionary<uint, byte> {
+					{ 42, 3 },
+					{ 43, 3 },
+					{ 44, 3 }
+				}
+			);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (43, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (43, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (43, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -169,7 +303,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
 				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
@@ -179,12 +313,13 @@ namespace ArchiSteamFarm.Tests {
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
-		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, uint appID = (uint) 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common, byte cardsPerSet = byte.MaxValue, uint amountPerCard = (uint) 0) =>
-			ArchiSteamFarm.Bot.GetItemsForFullBadge(
-				inventory, new Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte CardsPerSet)> {
-					{ (appID, type, rarity), (amountPerCard, cardsPerSet) }
-				}
-			).ToHashSet();
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, uint appID = (uint) 42, byte cardsPerSet = byte.MaxValue) => GetItemsForFullBadge(inventory, new Dictionary<uint, byte> { { appID, cardsPerSet } });
+
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IDictionary<uint, byte> cardsPerSet) {
+			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> inventorySets = ArchiSteamFarm.Trading.GetInventorySets(inventory);
+
+			return ArchiSteamFarm.Bot.GetItemsForFullBadge(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID]))).ToHashSet();
+		}
 
 		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = (uint) 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
 

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -19,7 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArchiSteamFarm.Json;
@@ -28,12 +27,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ArchiSteamFarm.Tests {
 	[TestClass]
 	public sealed class Bot {
-		private const uint DefaultRealAppID = 42;
-		private const Steam.Asset.EType DefaultAssetType = Steam.Asset.EType.TradingCard;
-		private const Steam.Asset.ERarity DefaultRarity = Steam.Asset.ERarity.Common;
-		private const uint DefaultAmountPerCard = 0;
-		private const byte DefaultCardsPerSet = byte.MaxValue;
-
 		[TestMethod]
 		public void NotAllCardsPresent() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
@@ -42,7 +35,9 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 3, 0);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
@@ -53,7 +48,13 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 2, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
@@ -66,7 +67,13 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 2);
-			AssertFullSets(itemsToSend, 2, 2);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
@@ -78,7 +85,13 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 2);
-			AssertFullSets(itemsToSend, 2, 2);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
@@ -91,40 +104,62 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 3, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
 		public void CardsWithOtherRarity() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, rarity: DefaultRarity),
+				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
 				CreateCard(1, rarity: Steam.Asset.ERarity.Rare)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 1, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
 		public void CardsWithOtherType() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, type: DefaultAssetType),
+				CreateCard(1, type: Steam.Asset.EType.TradingCard),
 				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 1, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
 		public void CardsWithOtherAppID() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, DefaultRealAppID),
-				CreateCard(1, DefaultRealAppID + 1),
+				CreateCard(1, 42),
+				CreateCard(1, (uint) 42 + 1),
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 1, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
 		[TestMethod]
@@ -135,35 +170,27 @@ namespace ArchiSteamFarm.Tests {
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2, amountPerCard: 1);
-			AssertFullSets(itemsToSend, 2, 1);
+
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
+				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 }
+			};
+
+			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
-		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, uint appID = DefaultRealAppID, Steam.Asset.EType type = DefaultAssetType, Steam.Asset.ERarity rarity = DefaultRarity, byte cardsPerSet = DefaultCardsPerSet, uint amountPerCard = DefaultAmountPerCard) =>
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, uint appID = (uint) 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common, byte cardsPerSet = byte.MaxValue, uint amountPerCard = (uint) 0) =>
 			ArchiSteamFarm.Bot.GetItemsForFullBadge(
 				inventory, new Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte CardsPerSet)> {
 					{ (appID, type, rarity), (amountPerCard, cardsPerSet) }
 				}
 			).ToHashSet();
 
-		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = DefaultRealAppID, Steam.Asset.EType type = DefaultAssetType, Steam.Asset.ERarity rarity = DefaultRarity) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
+		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = (uint) 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
 
-		private static void AssertFullSets(HashSet<Steam.Asset> itemsToSend, byte cardsInSet, byte expectedSets) {
-			if (expectedSets > 0) {
-				AssertAllCardsPresent(itemsToSend, cardsInSet);
-				AssertEqualAmounts(itemsToSend);
-				AssertEqualRealAppID(itemsToSend);
-				AssertEqualType(itemsToSend);
-			}
-
-			Assert.AreEqual(expectedSets, itemsToSend.GroupBy(item => item.ClassID).FirstOrDefault()?.Select(item => item.Amount).Aggregate((a, b) => a + b) ?? 0);
+		private static void AssertResultMatchesExpectation(Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult, IEnumerable<Steam.Asset> itemsToSend) {
+			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), long> realResult = itemsToSend.GroupBy(asset => (asset.RealAppID, asset.ContextID, asset.ClassID)).ToDictionary(group => group.Key, group => group.Sum(asset => asset.Amount));
+			Assert.IsTrue(expectedResult.All(expectation => realResult.TryGetValue(expectation.Key, out long reality) && (expectation.Value == reality)));
 		}
-
-		private static void AssertEqualAmounts(IEnumerable<Steam.Asset> itemsToSend) => Assert.AreEqual(1, itemsToSend.GroupBy(item => item.ClassID).Select(group => group.Select(item => item.Amount).Aggregate((a, b) => a + b)).GroupBy(count => count).Count());
-
-		private static void AssertEqualRealAppID(IEnumerable<Steam.Asset> itemsToSend) => Assert.AreEqual(1, itemsToSend.GroupBy(item => item.RealAppID).Count());
-
-		private static void AssertEqualType(IEnumerable<Steam.Asset> itemsToSend) => Assert.AreEqual(1, itemsToSend.GroupBy(anyItem => anyItem.Type).Count());
-
-		private static void AssertAllCardsPresent(IEnumerable<Steam.Asset> itemsToSend, byte cardsInSet) => Assert.AreEqual(cardsInSet, itemsToSend.GroupBy(item => item.ClassID).Count());
 	}
 }

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -19,6 +19,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ArchiSteamFarm.Json;
@@ -155,11 +156,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Common),
 				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
 				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, AppID1, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Uncommon)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
@@ -210,11 +207,7 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard),
 				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard),
 				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown),
-				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown)
+				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
@@ -234,23 +227,8 @@ namespace ArchiSteamFarm.Tests {
 				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
 				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-
 				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
 				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-
-				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
 
 				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
 				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
@@ -324,17 +302,35 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(ArgumentException))]
+		public void TooManyCardsPerSet() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, AppID1),
+				CreateCard(2, AppID1),
+				CreateCard(3, AppID1),
+				CreateCard(4, AppID1)
+			};
+
+			GetItemsForFullBadge(
+				items, new Dictionary<uint, byte> {
+					{ AppID1, 3 },
+					{ AppID2, 3 },
+					{ AppID3, 3 }
+				}
+			);
+
+			Assert.Fail();
+		}
+
+		[TestMethod]
 		public void OtherAppIDOneSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
 				CreateCard(1, realAppID: AppID1),
 				CreateCard(2, realAppID: AppID1),
+
 				CreateCard(1, realAppID: AppID2),
 				CreateCard(2, realAppID: AppID2),
-				CreateCard(3, realAppID: AppID2),
-				CreateCard(1, realAppID: AppID3),
-				CreateCard(2, realAppID: AppID3),
-				CreateCard(3, realAppID: AppID3),
-				CreateCard(4, realAppID: AppID3)
+				CreateCard(3, realAppID: AppID2)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -27,14 +27,18 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ArchiSteamFarm.Tests {
 	[TestClass]
 	public sealed class Bot {
+		private const uint AppID1 = 42;
+		private const uint AppID2 = 43;
+		private const uint AppID3 = 44;
+
 		[TestMethod]
 		public void NotAllCardsPresent() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1),
-				CreateCard(2)
+				CreateCard(1, AppID1),
+				CreateCard(2, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -43,15 +47,15 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OneSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1),
-				CreateCard(2)
+				CreateCard(1, AppID1),
+				CreateCard(2, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -60,17 +64,17 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void MultipleSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1),
-				CreateCard(1),
-				CreateCard(2),
-				CreateCard(2)
+				CreateCard(1, AppID1),
+				CreateCard(1, AppID1),
+				CreateCard(2, AppID1),
+				CreateCard(2, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -79,16 +83,16 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void MultipleSetsDifferentAmount() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, 2),
-				CreateCard(2),
-				CreateCard(2)
+				CreateCard(1, AppID1, 2),
+				CreateCard(2, AppID1),
+				CreateCard(2, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -97,18 +101,18 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void MoreCardsThanNeeded() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1),
-				CreateCard(1),
-				CreateCard(2),
-				CreateCard(3)
+				CreateCard(1, AppID1),
+				CreateCard(1, AppID1),
+				CreateCard(2, AppID1),
+				CreateCard(3, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -117,14 +121,14 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherRarityFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -133,11 +137,11 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherRarityNoSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 
@@ -147,23 +151,23 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherRarityOneSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(1, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, AppID1, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -172,14 +176,14 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherTypeFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard)
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -188,11 +192,11 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherTypeNoSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard)
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 
@@ -202,23 +206,23 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherTypeOneSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(2, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(3, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(1, type: Steam.Asset.EType.Unknown),
-				CreateCard(2, type: Steam.Asset.EType.Unknown),
-				CreateCard(3, type: Steam.Asset.EType.Unknown),
-				CreateCard(4, type: Steam.Asset.EType.Unknown)
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown),
+				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -227,52 +231,52 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void MutliRarityAndType() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
 
-				CreateCard(1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Uncommon),
 
-				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Rare),
 
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
 
 				// for better readability and easier verification when thinking about this test the items that shall be selected for sending are the ones below this comment
-				CreateCard(1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
 
-				CreateCard(1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(3, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(7, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(7, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(2, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 3);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 2 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 3), 3 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 4), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 7), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 3 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 4), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 7), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -281,20 +285,20 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherAppIDFullSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: 42),
-				CreateCard(1, realAppID: 43),
+				CreateCard(1, realAppID: AppID1),
+				CreateCard(1, realAppID: AppID2),
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ 42, 1 },
-					{ 43, 1 }
+					{ AppID1, 1 },
+					{ AppID2, 1 }
 				}
 			);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (43, Steam.Asset.SteamCommunityContextID, 1), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID2, Steam.Asset.SteamCommunityContextID, 1), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -303,14 +307,14 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherAppIDNoSets() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: 42),
-				CreateCard(1, realAppID: 43),
+				CreateCard(1, realAppID: AppID1),
+				CreateCard(1, realAppID: AppID2),
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ 42, 2 },
-					{ 43, 2 }
+					{ AppID1, 2 },
+					{ AppID2, 2 }
 				}
 			);
 
@@ -322,29 +326,29 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void OtherAppIDOneSet() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: 42),
-				CreateCard(2, realAppID: 42),
-				CreateCard(1, realAppID: 43),
-				CreateCard(2, realAppID: 43),
-				CreateCard(3, realAppID: 43),
-				CreateCard(1, realAppID: 44),
-				CreateCard(2, realAppID: 44),
-				CreateCard(3, realAppID: 44),
-				CreateCard(4, realAppID: 44)
+				CreateCard(1, realAppID: AppID1),
+				CreateCard(2, realAppID: AppID1),
+				CreateCard(1, realAppID: AppID2),
+				CreateCard(2, realAppID: AppID2),
+				CreateCard(3, realAppID: AppID2),
+				CreateCard(1, realAppID: AppID3),
+				CreateCard(2, realAppID: AppID3),
+				CreateCard(3, realAppID: AppID3),
+				CreateCard(4, realAppID: AppID3)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ 42, 3 },
-					{ 43, 3 },
-					{ 44, 3 }
+					{ AppID1, 3 },
+					{ AppID2, 3 },
+					{ AppID3, 3 }
 				}
 			);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (43, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (43, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (43, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (AppID2, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID2, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (AppID2, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -353,21 +357,21 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		public void TooHighAmount() {
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, 2),
-				CreateCard(2)
+				CreateCard(1, AppID1, 2),
+				CreateCard(2, AppID1)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, cardsPerSet: 2);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (42, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (42, Steam.Asset.SteamCommunityContextID, 2), 1 }
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
 		}
 
-		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, uint appID = (uint) 42, byte cardsPerSet = byte.MaxValue) => GetItemsForFullBadge(inventory, new Dictionary<uint, byte> { { appID, cardsPerSet } });
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, byte cardsPerSet, uint appID) => GetItemsForFullBadge(inventory, new Dictionary<uint, byte> { { appID, cardsPerSet } });
 
 		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IDictionary<uint, byte> cardsPerSet) {
 			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> inventorySets = ArchiSteamFarm.Trading.GetInventorySets(inventory);
@@ -375,9 +379,9 @@ namespace ArchiSteamFarm.Tests {
 			return ArchiSteamFarm.Bot.GetItemsForFullBadge(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID]))).ToHashSet();
 		}
 
-		private static Steam.Asset CreateCard(ulong classID, uint amount = 1, uint realAppID = (uint) 42, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
+		private static Steam.Asset CreateCard(ulong classID, uint realAppID, uint amount = 1, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
 
-		private static void AssertResultMatchesExpectation(Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult, IEnumerable<Steam.Asset> itemsToSend) {
+		private static void AssertResultMatchesExpectation(IReadOnlyDictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult, IReadOnlyCollection<Steam.Asset> itemsToSend) {
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), long> realResult = itemsToSend.GroupBy(asset => (asset.RealAppID, asset.ContextID, asset.ClassID)).ToDictionary(group => group.Key, group => group.Sum(asset => asset.Amount));
 			Assert.AreEqual(expectedResult.Count, realResult.Count);
 			Assert.IsTrue(expectedResult.All(expectation => realResult.TryGetValue(expectation.Key, out long reality) && (expectation.Value == reality)));

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -408,7 +408,7 @@ namespace ArchiSteamFarm.Tests {
 		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IDictionary<uint, byte> cardsPerSet) {
 			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> inventorySets = ArchiSteamFarm.Trading.GetInventorySets(inventory);
 
-			return ArchiSteamFarm.Bot.GetItemsForFullBadge(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID]))).ToHashSet();
+			return ArchiSteamFarm.Bot.GetItemsForFullSets(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID]))).ToHashSet();
 		}
 
 		private static Steam.Asset CreateCard(ulong classID, uint realAppID, uint amount = 1, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -28,18 +28,16 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace ArchiSteamFarm.Tests {
 	[TestClass]
 	public sealed class Bot {
-		private const uint AppID1 = 42;
-		private const uint AppID2 = 43;
-		private const uint AppID3 = 44;
-
 		[TestMethod]
 		public void NotAllCardsPresent() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1),
-				CreateCard(2, AppID1)
+				CreateCard(1, appID),
+				CreateCard(2, appID)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -47,16 +45,18 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OneSet() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1),
-				CreateCard(2, AppID1)
+				CreateCard(1, appID),
+				CreateCard(2, appID)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -64,18 +64,20 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void MultipleSets() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1),
-				CreateCard(1, AppID1),
-				CreateCard(2, AppID1),
-				CreateCard(2, AppID1)
+				CreateCard(1, appID),
+				CreateCard(1, appID),
+				CreateCard(2, appID),
+				CreateCard(2, appID)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -83,17 +85,19 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void MultipleSetsDifferentAmount() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, 2),
-				CreateCard(2, AppID1),
-				CreateCard(2, AppID1)
+				CreateCard(1, appID, 2),
+				CreateCard(2, appID),
+				CreateCard(2, appID)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -101,19 +105,21 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void MoreCardsThanNeeded() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1),
-				CreateCard(1, AppID1),
-				CreateCard(2, AppID1),
-				CreateCard(3, AppID1)
+				CreateCard(1, appID),
+				CreateCard(1, appID),
+				CreateCard(2, appID),
+				CreateCard(3, appID)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -121,15 +127,17 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherRarityFullSets() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -137,12 +145,14 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherRarityNoSets() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 
@@ -151,20 +161,22 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherRarityOneSet() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(1, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, AppID1, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, AppID1, rarity: Steam.Asset.ERarity.Uncommon)
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, appID, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, appID, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, appID, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, appID, rarity: Steam.Asset.ERarity.Uncommon)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -172,15 +184,17 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherTypeFullSets() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard)
+				CreateCard(1, appID, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 1, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 2 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -188,12 +202,14 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherTypeNoSets() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard)
+				CreateCard(1, appID, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint>(0);
 
@@ -202,20 +218,22 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherTypeOneSet() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard),
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard)
+				CreateCard(1, appID, type: Steam.Asset.EType.TradingCard),
+				CreateCard(2, appID, type: Steam.Asset.EType.TradingCard),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(2, appID, type: Steam.Asset.EType.FoilTradingCard),
+				CreateCard(3, appID, type: Steam.Asset.EType.FoilTradingCard)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -223,38 +241,40 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void MutliRarityAndType() {
+			const uint appID = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, appID, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(2, appID, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Uncommon),
 
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(2, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Rare),
 
 				// for better readability and easier verification when thinking about this test the items that shall be selected for sending are the ones below this comment
-				CreateCard(1, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(2, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(1, appID, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(2, appID, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
+				CreateCard(3, appID, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Uncommon),
 
-				CreateCard(1, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
-				CreateCard(7, AppID1, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(1, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(3, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
+				CreateCard(7, appID, type: Steam.Asset.EType.FoilTradingCard, rarity: Steam.Asset.ERarity.Common),
 
-				CreateCard(2, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(3, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
-				CreateCard(4, AppID1, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare)
+				CreateCard(2, appID, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(3, appID, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare),
+				CreateCard(4, appID, type: Steam.Asset.EType.Unknown, rarity: Steam.Asset.ERarity.Rare)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 3, appID);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 2 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 2 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 3), 3 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 4), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 7), 1 }
+				{ (appID, Steam.Asset.SteamCommunityContextID, 1), 2 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 2), 2 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 3), 3 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 4), 1 },
+				{ (appID, Steam.Asset.SteamCommunityContextID, 7), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -262,21 +282,24 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherAppIDFullSets() {
+			const uint appID0 = 42;
+			const uint appID1 = 43;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: AppID1),
-				CreateCard(1, realAppID: AppID2),
+				CreateCard(1, realAppID: appID0),
+				CreateCard(1, realAppID: appID1),
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ AppID1, 1 },
-					{ AppID2, 1 }
+					{ appID0, 1 },
+					{ appID1, 1 }
 				}
 			);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID2, Steam.Asset.SteamCommunityContextID, 1), 1 }
+				{ (appID0, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID1, Steam.Asset.SteamCommunityContextID, 1), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -284,15 +307,18 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherAppIDNoSets() {
+			const uint appID0 = 42;
+			const uint appID1 = 43;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: AppID1),
-				CreateCard(1, realAppID: AppID2),
+				CreateCard(1, realAppID: appID0),
+				CreateCard(1, realAppID: appID1),
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ AppID1, 2 },
-					{ AppID2, 2 }
+					{ appID0, 2 },
+					{ appID1, 2 }
 				}
 			);
 
@@ -304,18 +330,22 @@ namespace ArchiSteamFarm.Tests {
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentOutOfRangeException))]
 		public void TooManyCardsPerSet() {
+			const uint appID0 = 42;
+			const uint appID1 = 43;
+			const uint appID2 = 44;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1),
-				CreateCard(2, AppID1),
-				CreateCard(3, AppID1),
-				CreateCard(4, AppID1)
+				CreateCard(1, appID0),
+				CreateCard(2, appID0),
+				CreateCard(3, appID0),
+				CreateCard(4, appID0)
 			};
 
 			GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ AppID1, 3 },
-					{ AppID2, 3 },
-					{ AppID3, 3 }
+					{ appID0, 3 },
+					{ appID1, 3 },
+					{ appID2, 3 }
 				}
 			);
 
@@ -324,27 +354,31 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void OtherAppIDOneSet() {
-			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, realAppID: AppID1),
-				CreateCard(2, realAppID: AppID1),
+			const uint appID0 = 42;
+			const uint appID1 = 43;
+			const uint appID2 = 44;
 
-				CreateCard(1, realAppID: AppID2),
-				CreateCard(2, realAppID: AppID2),
-				CreateCard(3, realAppID: AppID2)
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, realAppID: appID0),
+				CreateCard(2, realAppID: appID0),
+
+				CreateCard(1, realAppID: appID1),
+				CreateCard(2, realAppID: appID1),
+				CreateCard(3, realAppID: appID1)
 			};
 
 			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(
 				items, new Dictionary<uint, byte> {
-					{ AppID1, 3 },
-					{ AppID2, 3 },
-					{ AppID3, 3 }
+					{ appID0, 3 },
+					{ appID1, 3 },
+					{ appID2, 3 }
 				}
 			);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID2, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID2, Steam.Asset.SteamCommunityContextID, 2), 1 },
-				{ (AppID2, Steam.Asset.SteamCommunityContextID, 3), 1 }
+				{ (appID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID1, Steam.Asset.SteamCommunityContextID, 2), 1 },
+				{ (appID1, Steam.Asset.SteamCommunityContextID, 3), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);
@@ -352,16 +386,18 @@ namespace ArchiSteamFarm.Tests {
 
 		[TestMethod]
 		public void TooHighAmount() {
+			const uint appID0 = 42;
+
 			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
-				CreateCard(1, AppID1, 2),
-				CreateCard(2, AppID1)
+				CreateCard(1, appID0, 2),
+				CreateCard(2, appID0)
 			};
 
-			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, AppID1);
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID0);
 
 			Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> expectedResult = new Dictionary<(uint RealAppID, ulong ContextID, ulong ClassID), uint> {
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 1), 1 },
-				{ (AppID1, Steam.Asset.SteamCommunityContextID, 2), 1 }
+				{ (appID0, Steam.Asset.SteamCommunityContextID, 1), 1 },
+				{ (appID0, Steam.Asset.SteamCommunityContextID, 2), 1 }
 			};
 
 			AssertResultMatchesExpectation(expectedResult, itemsToSend);

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -1,0 +1,126 @@
+//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// |
+// Copyright 2015-2020 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using ArchiSteamFarm.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static ArchiSteamFarm.Bot;
+
+namespace ArchiSteamFarm.Tests {
+	[TestClass]
+	public sealed class Bot {
+		[TestMethod]
+		public void NotAllCardsPresent() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1),
+				CreateCard(2)
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 3);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == 0);
+		}
+
+		[TestMethod]
+		public void OneSet() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1),
+				CreateCard(2)
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 2);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == items.Count);
+		}
+
+		[TestMethod]
+		public void MultipleSets() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1),
+				CreateCard(1),
+				CreateCard(2),
+				CreateCard(2)
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 2);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == items.Count);
+		}
+
+		[TestMethod]
+		public void MultipleSetsDifferentAmount() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, 2),
+				CreateCard(2),
+				CreateCard(2)
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 2);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == items.Count);
+		}
+
+		[TestMethod]
+		public void MoreCardsThanNeeded() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1),
+				CreateCard(1),
+				CreateCard(2),
+				CreateCard(3),
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 3);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == 3);
+		}
+
+		[TestMethod]
+		public void TooHighAmount() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, 2),
+				CreateCard(2)
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 2);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == 0);
+		}
+
+		[TestMethod]
+		public void PartiallyHighAmount() {
+			HashSet<Steam.Asset> items = new HashSet<Steam.Asset> {
+				CreateCard(1, 5),
+				CreateCard(1, 4),
+				CreateCard(1),
+				CreateCard(2, 2),
+				CreateCard(2, 2),
+				CreateCard(2, 2),
+				CreateCard(2, 2),
+			};
+
+			HashSet<Steam.Asset>? itemsToSend = GetItemsForFullBadge(items, 2);
+			Assert.IsNotNull(itemsToSend);
+			Assert.IsTrue(itemsToSend.Count == 5);
+		}
+
+		private static Steam.Asset CreateCard(ulong classID, uint amount = 1) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: 42, type: Steam.Asset.EType.TradingCard, rarity: Steam.Asset.ERarity.Common);
+	}
+}

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -245,8 +245,8 @@ namespace ArchiSteamFarm {
 
 		[PublicAPI]
 		public async Task<(bool Success, string Message)> SendInventory(IReadOnlyCollection<Steam.Asset> items, ulong targetSteamID = 0, string? tradeToken = null) {
-			if (items.Count == 0) {
-				return (false, string.Format(Strings.ErrorIsEmpty, nameof(items)));
+			if ((items == null) || (items.Count == 0)) {
+				throw new ArgumentNullException(nameof(items));
 			}
 
 			if (!Bot.IsConnectedAndLoggedOn) {

--- a/ArchiSteamFarm/Actions.cs
+++ b/ArchiSteamFarm/Actions.cs
@@ -244,9 +244,9 @@ namespace ArchiSteamFarm {
 		}
 
 		[PublicAPI]
-		public async Task<(bool Success, string Message)> SendInventory(ulong targetSteamID = 0, string? tradeToken = null, IReadOnlyCollection<Steam.Asset>? inventory = null) {
-			if ((inventory == null) || (inventory.Count == 0)) {
-				return (false, string.Format(Strings.ErrorIsEmpty, nameof(inventory)));
+		public async Task<(bool Success, string Message)> SendInventory(IReadOnlyCollection<Steam.Asset> items, ulong targetSteamID = 0, string? tradeToken = null) {
+			if (items.Count == 0) {
+				return (false, string.Format(Strings.ErrorIsEmpty, nameof(items)));
 			}
 
 			if (!Bot.IsConnectedAndLoggedOn) {
@@ -296,7 +296,7 @@ namespace ArchiSteamFarm {
 					}
 				}
 
-				(bool success, HashSet<ulong>? mobileTradeOfferIDs) = await Bot.ArchiWebHandler.SendTradeOffer(targetSteamID, inventory, token: tradeToken).ConfigureAwait(false);
+				(bool success, HashSet<ulong>? mobileTradeOfferIDs) = await Bot.ArchiWebHandler.SendTradeOffer(targetSteamID, items, token: tradeToken).ConfigureAwait(false);
 
 				if ((mobileTradeOfferIDs != null) && (mobileTradeOfferIDs.Count > 0) && Bot.HasMobileAuthenticator) {
 					(bool twoFactorSuccess, _) = await HandleTwoFactorAuthenticationConfirmations(true, MobileAuthenticator.Confirmation.EType.Trade, mobileTradeOfferIDs, true).ConfigureAwait(false);
@@ -342,7 +342,7 @@ namespace ArchiSteamFarm {
 				return (false, string.Format(Strings.WarningFailedWithError, e.Message));
 			}
 
-			return await SendInventory(targetSteamID, tradeToken, inventory).ConfigureAwait(false);
+			return await SendInventory(inventory, targetSteamID, tradeToken).ConfigureAwait(false);
 		}
 
 		[PublicAPI]

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -20,6 +20,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -41,7 +42,7 @@ using Formatting = Newtonsoft.Json.Formatting;
 
 namespace ArchiSteamFarm {
 	public sealed class ArchiWebHandler : IDisposable {
-		private static readonly Dictionary<uint, byte> CachedCardCountsForGame = new Dictionary<uint, byte>();
+		private static readonly ConcurrentDictionary<uint, byte> CachedCardCountsForGame = new ConcurrentDictionary<uint, byte>();
 
 		[PublicAPI]
 		public const string SteamCommunityURL = "https://" + SteamCommunityHost;
@@ -1723,7 +1724,7 @@ namespace ArchiSteamFarm {
 			}
 
 			result = (byte) htmlNodes.Count;
-			CachedCardCountsForGame.Add(appID, result);
+			CachedCardCountsForGame.TryAdd(appID, result);
 
 			return result;
 		}

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1716,6 +1716,8 @@ namespace ArchiSteamFarm {
 			using IDocument? htmlDocument = await GetGameCardsPage(appID).ConfigureAwait(false);
 
 			if (htmlDocument == null) {
+				Bot.ArchiLogger.LogNullError(nameof(htmlDocument));
+
 				return 0;
 			}
 

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1701,6 +1701,30 @@ namespace ArchiSteamFarm {
 			return result;
 		}
 
+		internal async Task<byte> GetCardCountForGame(uint appID) {
+			if (appID == 0) {
+				Bot.ArchiLogger.LogNullError(nameof(appID));
+
+				return 0;
+			}
+
+			using IDocument? htmlDocument = await GetGameCardsPage(appID).ConfigureAwait(false);
+
+			if (htmlDocument == null) {
+				return 0;
+			}
+
+			List<IElement> htmlNodes = htmlDocument.SelectNodes("//div[@class='badge_detail_tasks']//div[@class='badge_card_set_text ellipsis']");
+
+			if ((htmlNodes.Count == 0) || (htmlNodes.Count % 2 != 0)) {
+				Bot.ArchiLogger.LogNullError(nameof(htmlNodes));
+
+				return 0;
+			}
+
+			return (byte) (htmlNodes.Count / 2);
+		}
+
 		internal async Task<IDocument?> GetGameCardsPage(uint appID) {
 			if (appID == 0) {
 				throw new ArgumentNullException(nameof(appID));

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1705,6 +1705,10 @@ namespace ArchiSteamFarm {
 		}
 
 		internal async Task<byte> GetCardCountForGame(uint appID) {
+			if (appID == 0) {
+				throw new ArgumentNullException(nameof(appID));
+			}
+
 			if (CachedCardCountsForGame.TryGetValue(appID, out byte result)) {
 				return result;
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2857,9 +2857,6 @@ namespace ArchiSteamFarm {
 				return new HashSet<uint>(0);
 			}
 
-			// We need a collection that does not discard duplicates, as we will get the same ID for normal as well as foil badges
-			List<uint> appIDs = GetCompletedBadgeAppIDs(badgePage);
-
 			byte maxPages = 1;
 			IElement? htmlNode = badgePage.SelectSingleNode("(//a[@class='pagelink'])[last()]");
 
@@ -2878,6 +2875,9 @@ namespace ArchiSteamFarm {
 					return new HashSet<uint>(0);
 				}
 			}
+
+			// We need a collection that does not discard duplicates, as we will get the same ID for normal as well as foil badges
+			List<uint> appIDs = GetCompletedBadgeAppIDs(badgePage);
 
 			const byte maxBadgesPerPage = 150;
 			byte currentPage = 1;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2880,10 +2880,10 @@ namespace ArchiSteamFarm {
 			}
 
 			const byte maxBadgesPerPage = 150;
-			byte currentPage = 2;
+			byte currentPage = 1;
 
-			while ((currentPage < maxPages) && (appIDs.Count == currentPage * maxBadgesPerPage)) {
-				appIDs.AddRange(await GetCompletedBadgeAppIDs(currentPage++).ConfigureAwait(false));
+			while ((currentPage <= maxPages) && (appIDs.Count == currentPage * maxBadgesPerPage)) {
+				appIDs.AddRange(await GetCompletedBadgeAppIDs(++currentPage).ConfigureAwait(false));
 			}
 
 			return appIDs.ToHashSet();

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3097,7 +3097,7 @@ namespace ArchiSteamFarm {
 				}
 
 				if (cardsPerSet < itemsPerClassID.Count) {
-					throw new ArgumentException(nameof(inventory) + " || " + nameof(amountsToExtract));
+					throw new ArgumentOutOfRangeException(nameof(inventory) + " && " + nameof(amountsToExtract));
 				}
 
 				if (cardsPerSet > itemsPerClassID.Count) {
@@ -3105,14 +3105,14 @@ namespace ArchiSteamFarm {
 				}
 
 				foreach (List<Steam.Asset> itemsOfClass in itemsPerClassID.Values) {
-					long classRemaining = setsToExtract;
+					uint classRemaining = setsToExtract;
 
-					for (int i = 0; (classRemaining > 0) && (i < itemsOfClass.Count); ++i) {
+					for (int i = 0; (classRemaining > 0) && (i < itemsOfClass.Count); i++) {
 						Steam.Asset item = itemsOfClass[i];
 
 						if (item.Amount > classRemaining) {
 							Steam.Asset itemToSend = item.CreateShallowCopy();
-							itemToSend.Amount = (uint) classRemaining;
+							itemToSend.Amount = classRemaining;
 							result.Add(itemToSend);
 
 							classRemaining = 0;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2967,7 +2967,7 @@ namespace ArchiSteamFarm {
 				}
 
 				// URIs to foil badges are the same as for normal badges except they end with "?border=1"
-				string? appIDText = badgeUri.Split('/', StringSplitOptions.RemoveEmptyEntries)[^1].Split('?', StringSplitOptions.RemoveEmptyEntries)[0];
+				string? appIDText = badgeUri.Split('?', StringSplitOptions.RemoveEmptyEntries)[0].Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
 
 				if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
 					ArchiLogger.LogNullError(nameof(appID));
@@ -3040,7 +3040,7 @@ namespace ArchiSteamFarm {
 					return;
 				}
 
-				HashSet<Steam.Asset> result = GetItemsForFullBadge(inventory, itemsToTakePerInventorySet);
+				HashSet<Steam.Asset> result = GetItemsForFullSets(inventory, itemsToTakePerInventorySet);
 
 				if (result.Count > 0) {
 					await Actions.SendInventory(result).ConfigureAwait(false);
@@ -3082,7 +3082,7 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		internal static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte CardsPerSet)> amountsToExtract) {
+		internal static HashSet<Steam.Asset> GetItemsForFullSets(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte ItemsPerSet)> amountsToExtract) {
 			if ((inventory == null) || (inventory.Count == 0) || (amountsToExtract == null) || (amountsToExtract.Count == 0)) {
 				throw new ArgumentNullException(nameof(inventory) + " || " + nameof(amountsToExtract));
 			}
@@ -3090,16 +3090,16 @@ namespace ArchiSteamFarm {
 			HashSet<Steam.Asset> result = new HashSet<Steam.Asset>();
 			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), Dictionary<ulong, HashSet<Steam.Asset>>> itemsPerClassIDPerSet = inventory.GroupBy(item => (item.RealAppID, item.Type, item.Rarity)).ToDictionary(grouping => grouping.Key, grouping => grouping.GroupBy(item => item.ClassID).ToDictionary(group => group.Key, group => group.ToHashSet()));
 
-			foreach (((uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) set, (uint setsToExtract, byte cardsPerSet)) in amountsToExtract) {
+			foreach (((uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity) set, (uint setsToExtract, byte itemsPerSet)) in amountsToExtract) {
 				if (!itemsPerClassIDPerSet.TryGetValue(set, out Dictionary<ulong, HashSet<Steam.Asset>>? itemsPerClassID)) {
 					continue;
 				}
 
-				if (cardsPerSet < itemsPerClassID.Count) {
+				if (itemsPerSet < itemsPerClassID.Count) {
 					throw new ArgumentOutOfRangeException(nameof(inventory) + " && " + nameof(amountsToExtract));
 				}
 
-				if (cardsPerSet > itemsPerClassID.Count) {
+				if (itemsPerSet > itemsPerClassID.Count) {
 					continue;
 				}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3096,7 +3096,11 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
-				if (cardsPerSet != itemsPerClassID.Count) {
+				if (cardsPerSet < itemsPerClassID.Count) {
+					throw new ArgumentException(nameof(inventory) + " || " + nameof(amountsToExtract));
+				}
+
+				if (cardsPerSet > itemsPerClassID.Count) {
 					continue;
 				}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3050,7 +3050,7 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		private async Task<Dictionary<uint, byte>?> LoadCardsPerSet(HashSet<uint> appIDs) {
+		private async Task<Dictionary<uint, byte>?> LoadCardsPerSet(IReadOnlyCollection<uint> appIDs) {
 			if (appIDs == null) {
 				throw new ArgumentNullException(nameof(appIDs));
 			}
@@ -3082,7 +3082,7 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		internal static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte CardsPerSet)> amountsToExtract) {
+		internal static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte CardsPerSet)> amountsToExtract) {
 			if ((inventory == null) || (amountsToExtract == null) || (amountsToExtract.Count == 0) || (inventory.Count == 0)) {
 				throw new ArgumentNullException($"{nameof(inventory)} || {nameof(amountsToExtract)}");
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3035,7 +3035,7 @@ namespace ArchiSteamFarm {
 			return new HashSet<Steam.Asset>(0);
 		}
 
-		private static bool IsPossibleToSendAmountN(long n, IReadOnlyList<Steam.Asset> items, IList<bool> usedItems) {
+		private static bool IsPossibleToSendAmountN(long n, IList<Steam.Asset> items, IList<bool> usedItems) {
 			// try all combinations that do not go beyond n recursively and mark the used items
 			for (int i = 0; i < items.Count; ++i) {
 				if (usedItems[i]) {
@@ -3045,7 +3045,30 @@ namespace ArchiSteamFarm {
 				long remaining = n - items[i].Amount;
 
 				if (remaining < 0) {
-					continue;
+					Steam.Asset splittableItem = items[i];
+
+					items.RemoveAt(i);
+					usedItems.RemoveAt(i);
+
+					Steam.Asset splitItem = new Steam.Asset(
+						splittableItem.AppID,
+						splittableItem.ContextID,
+						splittableItem.ClassID,
+						Convert.ToUInt32(n),
+						splittableItem.InstanceID,
+						splittableItem.AssetID,
+						splittableItem.Marketable,
+						splittableItem.Tradable,
+						splittableItem.Tags,
+						splittableItem.RealAppID,
+						splittableItem.Type,
+						splittableItem.Rarity
+					);
+
+					items.Add(splitItem);
+					usedItems.Add(true);
+
+					return true;
 				}
 
 				usedItems[i] = true;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2852,7 +2852,8 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		private async Task<HashSet<uint>?> GetPossiblyCompletedBadgeAppIDs() {
+		[PublicAPI]
+		public async Task<HashSet<uint>?> GetPossiblyCompletedBadgeAppIDs() {
 			using IDocument? badgePage = await ArchiWebHandler.GetBadgePage(1).ConfigureAwait(false);
 
 			if (badgePage == null) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2846,7 +2846,7 @@ namespace ArchiSteamFarm {
 				Utilities.InBackground(ArchiWebHandler.MarkInventory);
 			}
 
-			if (BotConfig.SendSetsOnCompleted && !BotConfig.SetTypesToComplete.IsEmpty) {
+			if (!BotConfig.CompleteTypesToSend.IsEmpty) {
 				Utilities.InBackground(SendCompletedSets);
 			}
 		}
@@ -3009,7 +3009,7 @@ namespace ArchiSteamFarm {
 
 				try {
 					inventory = await ArchiWebHandler.GetInventoryAsync(SteamID)
-						.Where(item => item.Tradable && (BotConfig.SetTypesToComplete.Contains(item.Type) && appIDs.Contains(item.RealAppID)))
+						.Where(item => item.Tradable && (BotConfig.CompleteTypesToSend.Contains(item.Type) && appIDs.Contains(item.RealAppID)))
 						.ToHashSetAsync()
 						.ConfigureAwait(false);
 				} catch (HttpRequestException e) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2945,7 +2945,7 @@ namespace ArchiSteamFarm {
 
 			// We need to also select all badges that we have max level, as those will not display with a craft button
 			// Level 5 is maximum level for card badges according to https://steamcommunity.com/tradingcards/faq
-			linkElements.AddRange(badgePage.SelectNodes("//div[contains(@class, 'badge_row') and .//div[@class='badge_info_description']/div[contains(text(), 'Level 5')]]/a[@class='badge_row_overlay']"));
+			linkElements.AddRange(badgePage.SelectNodes("//div[@class='badges_sheet']/div[contains(@class, 'badge_row') and .//div[@class='badge_info_description']/div[contains(text(), 'Level 5')]]/a[@class='badge_row_overlay']"));
 
 			if (linkElements.Count == 0) {
 				return new HashSet<uint>(0);

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2846,7 +2846,7 @@ namespace ArchiSteamFarm {
 				Utilities.InBackground(ArchiWebHandler.MarkInventory);
 			}
 
-			if (!BotConfig.CompleteTypesToSend.IsEmpty) {
+			if (BotConfig.CompleteTypesToSend.Count > 0) {
 				Utilities.InBackground(SendCompletedSets);
 			}
 		}
@@ -3009,7 +3009,7 @@ namespace ArchiSteamFarm {
 
 				try {
 					inventory = await ArchiWebHandler.GetInventoryAsync(SteamID)
-						.Where(item => item.Tradable && (BotConfig.CompleteTypesToSend.Contains(item.Type) && appIDs.Contains(item.RealAppID)))
+						.Where(item => item.Tradable && appIDs.Contains(item.RealAppID) && BotConfig.CompleteTypesToSend.Contains(item.Type))
 						.ToHashSetAsync()
 						.ConfigureAwait(false);
 				} catch (HttpRequestException e) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2992,6 +2992,10 @@ namespace ArchiSteamFarm {
 		}
 
 		internal static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> availableItems, byte cardsPerBadge) {
+			if ((availableItems.GroupBy(item => item.RealAppID).Count() > 1) || (availableItems.GroupBy(item => item.Type).Count() > 1)) {
+				throw new ArgumentException(nameof(availableItems));
+			}
+
 			Dictionary<ulong, List<Steam.Asset>> itemsPerClassId = availableItems.GroupBy(item => item.ClassID).ToDictionary(grouping => grouping.Key, grouping => grouping.OrderByDescending(item => item.Amount).ToList());
 
 			if (itemsPerClassId.Keys.Count != cardsPerBadge) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3050,7 +3050,8 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		private async Task<Dictionary<uint, byte>?> LoadCardsPerSet(ISet<uint> appIDs) {
+		[PublicAPI]
+		public async Task<Dictionary<uint, byte>?> LoadCardsPerSet(ISet<uint> appIDs) {
 			if ((appIDs == null) || (appIDs.Count == 0)) {
 				throw new ArgumentNullException(nameof(appIDs));
 			}
@@ -3082,7 +3083,8 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		internal static HashSet<Steam.Asset> GetItemsForFullSets(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte ItemsPerSet)> amountsToExtract) {
+		[PublicAPI]
+		public static HashSet<Steam.Asset> GetItemsForFullSets(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte ItemsPerSet)> amountsToExtract) {
 			if ((inventory == null) || (inventory.Count == 0) || (amountsToExtract == null) || (amountsToExtract.Count == 0)) {
 				throw new ArgumentNullException(nameof(inventory) + " || " + nameof(amountsToExtract));
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3027,13 +3027,14 @@ namespace ArchiSteamFarm {
 				}
 
 				Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> inventorySets = Trading.GetInventorySets(inventory);
+				appIDs.IntersectWith(inventorySets.Where(kv => kv.Value.Count >= MinimumCardsPerBadge).Select(kv => kv.Key.RealAppID));
 				Dictionary<uint, byte>? cardCountPerAppID = await LoadCardsPerSet(appIDs).ConfigureAwait(false);
 
 				if ((cardCountPerAppID == null) || (cardCountPerAppID.Count == 0)) {
 					return;
 				}
 
-				Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint Sets, byte CardsPerSet)> itemsToTakePerInventorySet = inventorySets.Where(kv => kv.Value.Count >= MinimumCardsPerBadge).ToDictionary(kv => kv.Key, kv => (kv.Value[0], cardCountPerAppID[kv.Key.RealAppID]));
+				Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint Sets, byte CardsPerSet)> itemsToTakePerInventorySet = inventorySets.Where(kv => appIDs.Contains(kv.Key.RealAppID)).ToDictionary(kv => kv.Key, kv => (kv.Value[0], cardCountPerAppID[kv.Key.RealAppID]));
 
 				if (itemsToTakePerInventorySet.Values.All(value => value.Sets == 0)) {
 					return;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -2907,11 +2907,15 @@ namespace ArchiSteamFarm {
 
 					IList<HashSet<uint>?> results = await Utilities.InParallel(tasks).ConfigureAwait(false);
 
-					if (results.Any(result => result == null)) {
-						return null;
+					foreach (HashSet<uint>? result in results) {
+						if (result == null) {
+							return null;
+						}
+
+						firstPageResult.UnionWith(result);
 					}
 
-					return firstPageResult.Concat(results.SelectMany(result => result)).ToHashSet();
+					return firstPageResult;
 			}
 		}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3006,7 +3006,7 @@ namespace ArchiSteamFarm {
 				HashSet<Steam.Asset> inventory;
 
 				try {
-					inventory = await ArchiWebHandler.GetInventoryAsync(SteamID)
+					inventory = await ArchiWebHandler.GetInventoryAsync()
 						.Where(item => item.Tradable && appIDs.Contains(item.RealAppID) && BotConfig.CompleteTypesToSend.Contains(item.Type))
 						.ToHashSetAsync()
 						.ConfigureAwait(false);

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -3105,11 +3105,7 @@ namespace ArchiSteamFarm {
 				foreach (HashSet<Steam.Asset> itemsOfClass in itemsPerClassID.Values) {
 					uint classRemaining = setsToExtract;
 
-					foreach (Steam.Asset item in itemsOfClass) {
-						if (classRemaining <= 0) {
-							break;
-						}
-
+					foreach (Steam.Asset item in itemsOfClass.TakeWhile(item => classRemaining > 0)) {
 						if (item.Amount > classRemaining) {
 							Steam.Asset itemToSend = item.CreateShallowCopy();
 							itemToSend.Amount = classRemaining;

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -111,6 +111,9 @@ namespace ArchiSteamFarm {
 		private const byte SteamTradeTokenLength = 8;
 
 		[PublicAPI]
+		public static readonly ImmutableHashSet<Steam.Asset.EType> AllowedCompleteTypesToSend = ImmutableHashSet.Create(Steam.Asset.EType.TradingCard, Steam.Asset.EType.FoilTradingCard);
+
+		[PublicAPI]
 		public static readonly ImmutableList<EFarmingOrder> DefaultFarmingOrders = ImmutableList<EFarmingOrder>.Empty;
 
 		[PublicAPI]
@@ -328,6 +331,10 @@ namespace ArchiSteamFarm {
 				return (false, string.Format(Strings.ErrorConfigPropertyInvalid, nameof(LootableTypes), lootableType));
 			}
 
+			foreach (Steam.Asset.EType completableType in CompleteTypesToSend.Where(completableType => !Enum.IsDefined(typeof(Steam.Asset.EType), completableType) || !AllowedCompleteTypesToSend.Contains(completableType))) {
+				return (false, string.Format(Strings.ErrorConfigPropertyInvalid, nameof(CompleteTypesToSend), completableType));
+			}
+
 			foreach (Steam.Asset.EType matchableType in MatchableTypes.Where(matchableType => !Enum.IsDefined(typeof(Steam.Asset.EType), matchableType))) {
 				return (false, string.Format(Strings.ErrorConfigPropertyInvalid, nameof(MatchableTypes), matchableType));
 			}
@@ -535,6 +542,8 @@ namespace ArchiSteamFarm {
 		public bool ShouldSerializeTradingPreferences() => ShouldSerializeDefaultValues || (TradingPreferences != DefaultTradingPreferences);
 		public bool ShouldSerializeTransferableTypes() => ShouldSerializeDefaultValues || ((TransferableTypes != DefaultTransferableTypes) && !TransferableTypes.SetEquals(DefaultTransferableTypes));
 		public bool ShouldSerializeUseLoginKeys() => ShouldSerializeDefaultValues || (UseLoginKeys != DefaultUseLoginKeys);
+
+		public bool ShouldSerializeCompleteTypesToSend() => ShouldSerializeDefaultValues || ((CompleteTypesToSend != DefaultCompleteTypesToSend) && !CompleteTypesToSend.SetEquals(DefaultCompleteTypesToSend));
 
 		// ReSharper restore UnusedMember.Global
 	}

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -80,9 +80,6 @@ namespace ArchiSteamFarm {
 		public const bool DefaultSendOnFarmingFinished = false;
 
 		[PublicAPI]
-		public const bool DefaultSendSetsOnCompleted = false;
-
-		[PublicAPI]
 		public const byte DefaultSendTradePeriod = 0;
 
 		[PublicAPI]
@@ -123,7 +120,7 @@ namespace ArchiSteamFarm {
 		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultLootableTypes = ImmutableHashSet.Create(Steam.Asset.EType.BoosterPack, Steam.Asset.EType.FoilTradingCard, Steam.Asset.EType.TradingCard);
 
 		[PublicAPI]
-		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultSetTypesToComplete = ImmutableHashSet.Create(Steam.Asset.EType.TradingCard, Steam.Asset.EType.FoilTradingCard);
+		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultCompleteTypesToSend = ImmutableHashSet<Steam.Asset.EType>.Empty;
 
 		[PublicAPI]
 		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultMatchableTypes = ImmutableHashSet.Create(Steam.Asset.EType.TradingCard);
@@ -191,10 +188,7 @@ namespace ArchiSteamFarm {
 		public readonly bool SendOnFarmingFinished = DefaultSendOnFarmingFinished;
 
 		[JsonProperty(Required = Required.DisallowNull)]
-		public readonly bool SendSetsOnCompleted = DefaultSendSetsOnCompleted;
-
-		[JsonProperty(Required = Required.DisallowNull)]
-		public readonly ImmutableHashSet<Steam.Asset.EType> SetTypesToComplete = DefaultSetTypesToComplete;
+		public readonly ImmutableHashSet<Steam.Asset.EType> CompleteTypesToSend = DefaultCompleteTypesToSend;
 
 		[JsonProperty(Required = Required.DisallowNull)]
 		public readonly byte SendTradePeriod = DefaultSendTradePeriod;

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -80,6 +80,9 @@ namespace ArchiSteamFarm {
 		public const bool DefaultSendOnFarmingFinished = false;
 
 		[PublicAPI]
+		public const bool DefaultSendSetsOnCompleted = false;
+
+		[PublicAPI]
 		public const byte DefaultSendTradePeriod = 0;
 
 		[PublicAPI]
@@ -183,6 +186,9 @@ namespace ArchiSteamFarm {
 
 		[JsonProperty(Required = Required.DisallowNull)]
 		public readonly bool SendOnFarmingFinished = DefaultSendOnFarmingFinished;
+
+		[JsonProperty(Required = Required.DisallowNull)]
+		public readonly bool SendSetsOnCompleted = DefaultSendSetsOnCompleted;
 
 		[JsonProperty(Required = Required.DisallowNull)]
 		public readonly byte SendTradePeriod = DefaultSendTradePeriod;

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -123,6 +123,9 @@ namespace ArchiSteamFarm {
 		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultLootableTypes = ImmutableHashSet.Create(Steam.Asset.EType.BoosterPack, Steam.Asset.EType.FoilTradingCard, Steam.Asset.EType.TradingCard);
 
 		[PublicAPI]
+		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultSetTypesToComplete = ImmutableHashSet.Create(Steam.Asset.EType.TradingCard, Steam.Asset.EType.FoilTradingCard);
+
+		[PublicAPI]
 		public static readonly ImmutableHashSet<Steam.Asset.EType> DefaultMatchableTypes = ImmutableHashSet.Create(Steam.Asset.EType.TradingCard);
 
 		[PublicAPI]
@@ -189,6 +192,9 @@ namespace ArchiSteamFarm {
 
 		[JsonProperty(Required = Required.DisallowNull)]
 		public readonly bool SendSetsOnCompleted = DefaultSendSetsOnCompleted;
+
+		[JsonProperty(Required = Required.DisallowNull)]
+		public readonly ImmutableHashSet<Steam.Asset.EType> SetTypesToComplete = DefaultSetTypesToComplete;
 
 		[JsonProperty(Required = Required.DisallowNull)]
 		public readonly byte SendTradePeriod = DefaultSendTradePeriod;

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -345,7 +345,7 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		private static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> GetInventorySets(IReadOnlyCollection<Steam.Asset> inventory) {
+		internal static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> GetInventorySets(IReadOnlyCollection<Steam.Asset> inventory) {
 			if ((inventory == null) || (inventory.Count == 0)) {
 				throw new ArgumentNullException(nameof(inventory));
 			}

--- a/ArchiSteamFarm/Trading.cs
+++ b/ArchiSteamFarm/Trading.cs
@@ -345,7 +345,8 @@ namespace ArchiSteamFarm {
 			}
 		}
 
-		internal static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> GetInventorySets(IReadOnlyCollection<Steam.Asset> inventory) {
+		[PublicAPI]
+		public static Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> GetInventorySets(IReadOnlyCollection<Steam.Asset> inventory) {
 			if ((inventory == null) || (inventory.Count == 0)) {
 				throw new ArgumentNullException(nameof(inventory));
 			}


### PR DESCRIPTION
Implements looting complete sets by adding config property `SendSetsOnCompleted` as requested in issue #852 (marked with PR-ok label)