### PR TITLE
Fix parsing tags in GetActiveTradeOffers

### DIFF
--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1527,7 +1527,8 @@ namespace ArchiSteamFarm {
 
 						string? value = tag["internal_name"].AsString();
 
-						if (string.IsNullOrEmpty(value)) {
+						// Apparently, name can be empty, but not null
+						if (value == null) {
 							Bot.ArchiLogger.LogNullError(nameof(value));
 
 							return null;

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -261,7 +261,7 @@ namespace ArchiSteamFarm.Json {
 
 				internal Tag(string identifier, string value) {
 					Identifier = !string.IsNullOrEmpty(identifier) ? identifier : throw new ArgumentNullException(nameof(identifier));
-					Value = value ?? throw new ArgumentNullException(nameof(identifier));
+					Value = value ?? throw new ArgumentNullException(nameof(value));
 				}
 
 				[JsonConstructor]

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -261,7 +261,7 @@ namespace ArchiSteamFarm.Json {
 
 				internal Tag(string identifier, string value) {
 					Identifier = !string.IsNullOrEmpty(identifier) ? identifier : throw new ArgumentNullException(nameof(identifier));
-					Value = !string.IsNullOrEmpty(value) ? value : throw new ArgumentNullException(nameof(value));
+					Value = value;
 				}
 
 				[JsonConstructor]

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -261,7 +261,7 @@ namespace ArchiSteamFarm.Json {
 
 				internal Tag(string identifier, string value) {
 					Identifier = !string.IsNullOrEmpty(identifier) ? identifier : throw new ArgumentNullException(nameof(identifier));
-					Value = value;
+					Value = value ?? throw new ArgumentNullException(nameof(identifier));
 				}
 
 				[JsonConstructor]


### PR DESCRIPTION
Tag value `internal_name` can be empty for some items, example (TF2 asset):

```json
{
    "tags": [
        {
            "category": "Quality",
            "internal_name": "Unique",
            "localized_category_name": "Quality",
            "localized_tag_name": "Unique",
            "color": "7D6D00"
        },
        {
            "category": "Type",
            "internal_name": "",
            "localized_category_name": "Type",
            "localized_tag_name": ""
        }
    ]
}
```