### PR TITLE
Fix ICrossProcessSemaphore interface members visibility

### DIFF
--- a/ArchiSteamFarm/Helpers/ICrossProcessSemaphore.cs
+++ b/ArchiSteamFarm/Helpers/ICrossProcessSemaphore.cs
@@ -25,8 +25,8 @@ using JetBrains.Annotations;
 namespace ArchiSteamFarm.Helpers {
 	[PublicAPI]
 	public interface ICrossProcessSemaphore {
-		internal void Release();
-		internal Task WaitAsync();
-		internal Task<bool> WaitAsync(int millisecondsTimeout);
+		void Release();
+		Task WaitAsync();
+		Task<bool> WaitAsync(int millisecondsTimeout);
 	}
 }


### PR DESCRIPTION
It's impossible for plugins to implement this interface if its members are internal.