### PR TITLE
Limit full set trades

### DIFF
--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -51,6 +51,22 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		public void TooManyCardsForSingleTrade() {
+			const uint appID = 42;
+
+			HashSet<Steam.Asset> items = new();
+
+			for (uint i = 0; i < ArchiSteamFarm.Trading.MaxItemsPerTrade; ++i) {
+				items.Add(CreateCard(1, appID));
+				items.Add(CreateCard(2, appID));
+			}
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, 2, appID);
+
+			Assert.IsTrue(itemsToSend.Count <= ArchiSteamFarm.Trading.MaxItemsPerTrade);
+		}
+
+		[TestMethod]
 		public void MultipleSets() {
 			const uint appID = 42;
 

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -62,7 +62,7 @@ namespace ArchiSteamFarm.Tests {
 			HashSet<Steam.Asset> items = new();
 
 			foreach ((uint appID, byte cards) in itemsPerSet) {
-				for (byte i = 1; i <= cards; ++i) {
+				for (byte i = 1; i <= cards; i++) {
 					items.Add(CreateCard(i, appID));
 				}
 			}

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -67,6 +67,30 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		public void TooManyCardsForSingleTradeMultipleAppIDs() {
+			const uint appID0 = 42;
+			const uint appID1 = 43;
+
+			HashSet<Steam.Asset> items = new();
+
+			for (byte i = 0; i < 100; i++) {
+				items.Add(CreateCard(1, appID0));
+				items.Add(CreateCard(2, appID0));
+				items.Add(CreateCard(1, appID1));
+				items.Add(CreateCard(2, appID1));
+			}
+
+			Dictionary<uint, byte> itemsPerSet = new() {
+				{ appID0, 2 },
+				{ appID1, 2 }
+			};
+
+			HashSet<Steam.Asset> itemsToSend = GetItemsForFullBadge(items, itemsPerSet);
+
+			Assert.IsTrue(itemsToSend.Count <= ArchiSteamFarm.Trading.MaxItemsPerTrade);
+		}
+
+		[TestMethod]
 		public void MultipleSets() {
 			const uint appID = 42;
 

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -51,6 +51,21 @@ namespace ArchiSteamFarm.Tests {
 		}
 
 		[TestMethod]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void MaxItemsTooSmall() {
+			const uint appID = 42;
+
+			HashSet<Steam.Asset> items = new() {
+				CreateCard(1, appID),
+				CreateCard(2, appID)
+			};
+
+			GetItemsForFullBadge(items, 2, appID, 4);
+
+			Assert.Fail();
+		}
+
+		[TestMethod]
 		public void TooManyCardsForSingleTrade() {
 			const uint appID = 42;
 
@@ -459,12 +474,12 @@ namespace ArchiSteamFarm.Tests {
 
 		private static Steam.Asset CreateCard(ulong classID, uint realAppID, uint amount = 1, Steam.Asset.EType type = Steam.Asset.EType.TradingCard, Steam.Asset.ERarity rarity = Steam.Asset.ERarity.Common) => new(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID: realAppID, type: type, rarity: rarity);
 
-		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, byte cardsPerSet, uint appID) => GetItemsForFullBadge(inventory, new Dictionary<uint, byte> { { appID, cardsPerSet } });
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, byte cardsPerSet, uint appID, ushort maxItems = ArchiSteamFarm.Trading.MaxItemsPerTrade) => GetItemsForFullBadge(inventory, new Dictionary<uint, byte> { { appID, cardsPerSet } }, maxItems);
 
-		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IDictionary<uint, byte> cardsPerSet) {
+		private static HashSet<Steam.Asset> GetItemsForFullBadge(IReadOnlyCollection<Steam.Asset> inventory, IDictionary<uint, byte> cardsPerSet, ushort maxItems = ArchiSteamFarm.Trading.MaxItemsPerTrade) {
 			Dictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), List<uint>> inventorySets = ArchiSteamFarm.Trading.GetInventorySets(inventory);
 
-			return ArchiSteamFarm.Bot.GetItemsForFullSets(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID]))).ToHashSet();
+			return ArchiSteamFarm.Bot.GetItemsForFullSets(inventory, inventorySets.ToDictionary(kv => kv.Key, kv => (SetsToExtract: inventorySets[kv.Key][0], cardsPerSet[kv.Key.RealAppID])), maxItems).ToHashSet();
 		}
 	}
 }

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -56,7 +56,7 @@ namespace ArchiSteamFarm.Tests {
 
 			HashSet<Steam.Asset> items = new();
 
-			for (uint i = 0; i < ArchiSteamFarm.Trading.MaxItemsPerTrade; ++i) {
+			for (byte i = 0; i < ArchiSteamFarm.Trading.MaxItemsPerTrade; i++) {
 				items.Add(CreateCard(1, appID));
 				items.Add(CreateCard(2, appID));
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -534,8 +534,8 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
-				uint maxSetsAllowed = Trading.MaxItemsPerTrade - (uint) result.Count;
-				maxSetsAllowed -= maxSetsAllowed % itemsPerSet;
+				byte maxSetsAllowed = (byte) (Trading.MaxItemsPerTrade - result.Count);
+				maxSetsAllowed -= (byte) (maxSetsAllowed % itemsPerSet);
 				maxSetsAllowed /= itemsPerSet;
 				uint realSetsToExtract = Math.Min(setsToExtract, maxSetsAllowed);
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -509,13 +509,17 @@ namespace ArchiSteamFarm {
 		}
 
 		[PublicAPI]
-		public static HashSet<Steam.Asset> GetItemsForFullSets(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte ItemsPerSet)> amountsToExtract) {
+		public static HashSet<Steam.Asset> GetItemsForFullSets(IReadOnlyCollection<Steam.Asset> inventory, IReadOnlyDictionary<(uint RealAppID, Steam.Asset.EType Type, Steam.Asset.ERarity Rarity), (uint SetsToExtract, byte ItemsPerSet)> amountsToExtract, ushort maxItems = Trading.MaxItemsPerTrade) {
 			if ((inventory == null) || (inventory.Count == 0)) {
 				throw new ArgumentNullException(nameof(inventory));
 			}
 
 			if ((amountsToExtract == null) || (amountsToExtract.Count == 0)) {
 				throw new ArgumentNullException(nameof(amountsToExtract));
+			}
+
+			if (maxItems < 5) {
+				throw new ArgumentOutOfRangeException(nameof(maxItems));
 			}
 
 			HashSet<Steam.Asset> result = new();
@@ -534,7 +538,7 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
-				byte maxSetsAllowed = (byte) (Trading.MaxItemsPerTrade - result.Count);
+				byte maxSetsAllowed = (byte) (maxItems - result.Count);
 				maxSetsAllowed -= (byte) (maxSetsAllowed % itemsPerSet);
 				maxSetsAllowed /= itemsPerSet;
 				byte realSetsToExtract = (byte) Math.Min(setsToExtract, maxSetsAllowed);

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -538,17 +538,17 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
-				byte maxSetsAllowed = (byte) (maxItems - result.Count);
-				maxSetsAllowed -= (byte) (maxSetsAllowed % itemsPerSet);
+				ushort maxSetsAllowed = (ushort) (maxItems - result.Count);
+				maxSetsAllowed -= (ushort) (maxSetsAllowed % itemsPerSet);
 				maxSetsAllowed /= itemsPerSet;
-				byte realSetsToExtract = (byte) Math.Min(setsToExtract, maxSetsAllowed);
+				ushort realSetsToExtract = (ushort) Math.Min(setsToExtract, maxSetsAllowed);
 
 				if (realSetsToExtract == 0) {
 					break;
 				}
 
 				foreach (HashSet<Steam.Asset> itemsOfClass in itemsPerClassID.Values) {
-					byte classRemaining = realSetsToExtract;
+					ushort classRemaining = realSetsToExtract;
 
 					foreach (Steam.Asset item in itemsOfClass.TakeWhile(_ => classRemaining > 0)) {
 						if (item.Amount > classRemaining) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -514,7 +514,7 @@ namespace ArchiSteamFarm {
 				throw new ArgumentNullException(nameof(inventory));
 			}
 
-			if ((amountsToExtract == null) || (amountsToExtract.Count == 0) || amountsToExtract.Any(kv => (kv.Value.ItemsPerSet < MinCardsPerBadge) || (kv.Value.SetsToExtract == 0))) {
+			if ((amountsToExtract == null) || (amountsToExtract.Count == 0) || amountsToExtract.Any(kv => kv.Value.SetsToExtract == 0)) {
 				throw new ArgumentNullException(nameof(amountsToExtract));
 			}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -560,7 +560,7 @@ namespace ArchiSteamFarm {
 						} else {
 							result.Add(item);
 
-							classRemaining -= (byte) item.Amount;
+							classRemaining -= (ushort) item.Amount;
 						}
 					}
 				}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -518,7 +518,7 @@ namespace ArchiSteamFarm {
 				throw new ArgumentNullException(nameof(amountsToExtract));
 			}
 
-			if (maxItems < 5) {
+			if (maxItems < MinimumCardsPerBadge) {
 				throw new ArgumentOutOfRangeException(nameof(maxItems));
 			}
 

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -537,7 +537,7 @@ namespace ArchiSteamFarm {
 				byte maxSetsAllowed = (byte) (Trading.MaxItemsPerTrade - result.Count);
 				maxSetsAllowed -= (byte) (maxSetsAllowed % itemsPerSet);
 				maxSetsAllowed /= itemsPerSet;
-				uint realSetsToExtract = Math.Min(setsToExtract, maxSetsAllowed);
+				byte realSetsToExtract = (byte) Math.Min(setsToExtract, maxSetsAllowed);
 
 				if (realSetsToExtract == 0) {
 					break;

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -534,8 +534,17 @@ namespace ArchiSteamFarm {
 					continue;
 				}
 
+				uint maxSetsAllowed = Trading.MaxItemsPerTrade - (uint) result.Count;
+				maxSetsAllowed -= maxSetsAllowed % itemsPerSet;
+				maxSetsAllowed /= itemsPerSet;
+				uint realSetsToExtract = Math.Min(setsToExtract, maxSetsAllowed);
+
+				if (realSetsToExtract == 0) {
+					break;
+				}
+
 				foreach (HashSet<Steam.Asset> itemsOfClass in itemsPerClassID.Values) {
-					uint classRemaining = setsToExtract;
+					uint classRemaining = realSetsToExtract;
 
 					foreach (Steam.Asset item in itemsOfClass.TakeWhile(_ => classRemaining > 0)) {
 						if (item.Amount > classRemaining) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -544,7 +544,7 @@ namespace ArchiSteamFarm {
 				}
 
 				foreach (HashSet<Steam.Asset> itemsOfClass in itemsPerClassID.Values) {
-					uint classRemaining = realSetsToExtract;
+					byte classRemaining = realSetsToExtract;
 
 					foreach (Steam.Asset item in itemsOfClass.TakeWhile(_ => classRemaining > 0)) {
 						if (item.Amount > classRemaining) {
@@ -556,7 +556,7 @@ namespace ArchiSteamFarm {
 						} else {
 							result.Add(item);
 
-							classRemaining -= item.Amount;
+							classRemaining -= (byte) item.Amount;
 						}
 					}
 				}


### PR DESCRIPTION
Currently it is possible for sets to be split up between up to 5 trade offers if there is more than 255 items to send. If this occurs and one of the trade offers times out or is declined full sets are split up between several accounts. This PR limits the items to be sent in this case to `Trading.MaxItemsPerTrade`.