### PR TITLE
Add blacklisting of AppIDs for MatchActively

### DIFF
--- a/ArchiSteamFarm/BotDatabase.cs
+++ b/ArchiSteamFarm/BotDatabase.cs
@@ -103,12 +103,14 @@ namespace ArchiSteamFarm {
 			BlacklistedFromTradesSteamIDs.OnModified += OnObjectModified;
 			IdlingBlacklistedAppIDs.OnModified += OnObjectModified;
 			IdlingPriorityAppIDs.OnModified += OnObjectModified;
+			MatchActivelyBlacklistedAppIDs.OnModified += OnObjectModified;
 		}
 
 		public override void Dispose() {
 			BlacklistedFromTradesSteamIDs.OnModified -= OnObjectModified;
 			IdlingBlacklistedAppIDs.OnModified -= OnObjectModified;
 			IdlingPriorityAppIDs.OnModified -= OnObjectModified;
+			MatchActivelyBlacklistedAppIDs.OnModified -= OnObjectModified;
 
 			BackingMobileAuthenticator?.Dispose();
 
@@ -214,6 +216,7 @@ namespace ArchiSteamFarm {
 		public bool ShouldSerializeGamesToRedeemInBackground() => HasGamesToRedeemInBackground;
 		public bool ShouldSerializeIdlingBlacklistedAppIDs() => IdlingBlacklistedAppIDs.Count > 0;
 		public bool ShouldSerializeIdlingPriorityAppIDs() => IdlingPriorityAppIDs.Count > 0;
+		public bool ShouldSerializeMatchActivelyBlacklistedAppIDs() => MatchActivelyBlacklistedAppIDs.Count > 0;
 
 		// ReSharper restore UnusedMember.Global
 	}

--- a/ArchiSteamFarm/BotDatabase.cs
+++ b/ArchiSteamFarm/BotDatabase.cs
@@ -42,6 +42,9 @@ namespace ArchiSteamFarm {
 		[JsonProperty(Required = Required.DisallowNull)]
 		internal readonly ConcurrentHashSet<uint> IdlingPriorityAppIDs = new();
 
+		[JsonProperty(Required = Required.DisallowNull)]
+		internal readonly ConcurrentHashSet<uint> MatchActivelyBlacklistedAppIDs = new();
+
 		internal uint GamesToRedeemInBackgroundCount {
 			get {
 				lock (GamesToRedeemInBackground) {

--- a/ArchiSteamFarm/Statistics.cs
+++ b/ArchiSteamFarm/Statistics.cs
@@ -366,7 +366,7 @@ namespace ArchiSteamFarm {
 			HashSet<Steam.Asset> ourInventory;
 
 			try {
-				ourInventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => acceptedMatchableTypes.Contains(item.Type)).ToHashSetAsync().ConfigureAwait(false);
+				ourInventory = await Bot.ArchiWebHandler.GetInventoryAsync().Where(item => acceptedMatchableTypes.Contains(item.Type) && !Bot.BotDatabase.MatchActivelyBlacklistedAppIDs.Contains(item.RealAppID)).ToHashSetAsync().ConfigureAwait(false);
 			} catch (HttpRequestException e) {
 				Bot.ArchiLogger.LogGenericWarningException(e);
 


### PR DESCRIPTION
Implements #2177
Commands added:
`mab [Bots]` - list all AppIDs from MatchActively blacklist
`mabadd [Bots] {AppIDs}` - add AppIDs to MatchActively blacklist
`mabrm [Bots] {AppIDs}` - remove AppIDs from MatchActively blacklist