### PR TITLE
Fix RandomNext behaviour

### DIFF
--- a/ArchiSteamFarm/Utilities.cs
+++ b/ArchiSteamFarm/Utilities.cs
@@ -208,7 +208,7 @@ namespace ArchiSteamFarm {
 				case < 0:
 					throw new ArgumentOutOfRangeException(nameof(maxValue));
 				case <= 1:
-					return maxValue;
+					return 0;
 				default:
 					lock (Random) {
 						return Random.Next(maxValue);


### PR DESCRIPTION
Fixes `RandomNext` method behaviour, since it gives incorrect value of `1` for input of `1` (Random.Next should give value **less** than input, unless it's 0).