### PR TITLE
Don't apply TargetLatestRuntimePatch for generic variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,11 @@ jobs:
         }
 
     - name: Publish ArchiSteamFarm.OfficialPlugins.SteamTokenDumper for .NET Core
-      run: dotnet publish "${{ env.STEAM_TOKEN_DUMPER_NAME }}" -c "${{ env.CONFIGURATION }}" -f "${{ env.NET_CORE_VERSION }}" -o "out/${{ env.STEAM_TOKEN_DUMPER_NAME }}/${{ env.NET_CORE_VERSION }}" -p:UseAppHost=false --nologo
+      run: dotnet publish "${{ env.STEAM_TOKEN_DUMPER_NAME }}" -c "${{ env.CONFIGURATION }}" -f "${{ env.NET_CORE_VERSION }}" -o "out/${{ env.STEAM_TOKEN_DUMPER_NAME }}/${{ env.NET_CORE_VERSION }}" -p:TargetLatestRuntimePatch=false -p:UseAppHost=false --nologo
 
     - name: Publish ArchiSteamFarm.OfficialPlugins.SteamTokenDumper for .NET Framework
       if: startsWith(matrix.os, 'windows-')
-      run: dotnet publish "${{ env.STEAM_TOKEN_DUMPER_NAME }}" -c "${{ env.CONFIGURATION }}" -f "${{ env.NET_FRAMEWORK_VERSION }}" -o "out/${{ env.STEAM_TOKEN_DUMPER_NAME }}/${{ env.NET_FRAMEWORK_VERSION }}" -p:UseAppHost=false --nologo
+      run: dotnet publish "${{ env.STEAM_TOKEN_DUMPER_NAME }}" -c "${{ env.CONFIGURATION }}" -f "${{ env.NET_FRAMEWORK_VERSION }}" -o "out/${{ env.STEAM_TOKEN_DUMPER_NAME }}/${{ env.NET_FRAMEWORK_VERSION }}" -p:TargetLatestRuntimePatch=false -p:UseAppHost=false --nologo
 
     - name: Perform cleanup of ArchiSteamFarm in preparation for publishing
       run: dotnet clean ArchiSteamFarm -c "${{ env.CONFIGURATION }}" -p:UseAppHost=false --nologo
@@ -121,7 +121,7 @@ jobs:
 
         publish() {
             if [ "$1" = 'generic' ]; then
-                local variantArgs="-p:UseAppHost=false"
+                local variantArgs="-p:TargetLatestRuntimePatch=false -p:UseAppHost=false"
             else
                 local variantArgs="-p:PublishSingleFile=true -p:PublishTrimmed=true -r $1"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
             }
 
             if ($variant -like 'generic*') {
-                $variantArgs = '-p:UseAppHost=false'
+                $variantArgs = '-p:TargetLatestRuntimePatch=false -p:UseAppHost=false'
             } else {
                 $variantArgs = '-p:PublishSingleFile=true', '-p:PublishTrimmed=true', '-r', "$variant"
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
             }
 
             if ($variant -like 'generic*') {
-                $variantArgs = '-p:TargetLatestRuntimePatch=false -p:UseAppHost=false'
+                $variantArgs = '-p:TargetLatestRuntimePatch=false', '-p:UseAppHost=false'
             } else {
                 $variantArgs = '-p:PublishSingleFile=true', '-p:PublishTrimmed=true', '-r', "$variant"
             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -175,7 +175,7 @@ after_test:
     }
 
 
-    dotnet publish "$env:STEAM_TOKEN_DUMPER_NAME" -c "$env:CONFIGURATION" -f "$env:NET_CORE_VERSION" -o "out/$env:STEAM_TOKEN_DUMPER_NAME/$env:NET_CORE_VERSION" -p:UseAppHost=false --nologo
+    dotnet publish "$env:STEAM_TOKEN_DUMPER_NAME" -c "$env:CONFIGURATION" -f "$env:NET_CORE_VERSION" -o "out/$env:STEAM_TOKEN_DUMPER_NAME/$env:NET_CORE_VERSION" -p:TargetLatestRuntimePatch=false -p:UseAppHost=false --nologo
 
 
     if ($LastExitCode -ne 0) {
@@ -183,7 +183,7 @@ after_test:
     }
 
 
-    dotnet publish "$env:STEAM_TOKEN_DUMPER_NAME" -c "$env:CONFIGURATION" -f "$env:NET_FRAMEWORK_VERSION" -o "out/$env:STEAM_TOKEN_DUMPER_NAME/$env:NET_FRAMEWORK_VERSION" -p:UseAppHost=false --nologo
+    dotnet publish "$env:STEAM_TOKEN_DUMPER_NAME" -c "$env:CONFIGURATION" -f "$env:NET_FRAMEWORK_VERSION" -o "out/$env:STEAM_TOKEN_DUMPER_NAME/$env:NET_FRAMEWORK_VERSION" -p:TargetLatestRuntimePatch=false -p:UseAppHost=false --nologo
 
 
     if ($LastExitCode -ne 0) {
@@ -222,7 +222,7 @@ after_test:
         }
 
         if ($variant -like 'generic*') {
-            $variantArgs = '-p:UseAppHost=false'
+            $variantArgs = '-p:TargetLatestRuntimePatch=false', '-p:UseAppHost=false'
         } else {
             $variantArgs = '-p:PublishSingleFile=true', '-p:PublishTrimmed=true', '-r', "$variant"
         }


### PR DESCRIPTION
I remember that previously I couldn't do that due to `dotnet restore` complaints, but it looks like with .NET 5.0 it's possible now, nice.

Doing this will stop requiring from users to use dotnet version higher or equal to the one the package was compiled with.