### PR TITLE
Manage package versions centrally

### DIFF
--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/ArchiSteamFarm.CustomPlugins.ExamplePlugin.csproj
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/ArchiSteamFarm.CustomPlugins.ExamplePlugin.csproj
@@ -4,14 +4,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" IncludeAssets="compile" Version="*" />
-    <PackageReference Include="SteamKit2" IncludeAssets="compile" Version="*" />
-    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" Version="*" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" IncludeAssets="compile" />
+    <PackageReference Include="SteamKit2" IncludeAssets="compile" />
+    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" IncludeAssets="compile" Version="*" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchiSteamFarm.CustomPlugins.PeriodicGC/ArchiSteamFarm.CustomPlugins.PeriodicGC.csproj
+++ b/ArchiSteamFarm.CustomPlugins.PeriodicGC/ArchiSteamFarm.CustomPlugins.PeriodicGC.csproj
@@ -4,8 +4,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" Version="5.0.0" />
-    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" Version="*" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" />
+    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper.csproj
+++ b/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper.csproj
@@ -4,15 +4,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" Version="5.0.0" />
-    <PackageReference Include="Newtonsoft.Json" IncludeAssets="compile" Version="*" />
-    <PackageReference Include="SteamKit2" IncludeAssets="compile" Version="*" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" IncludeAssets="compile" Version="*" />
-    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" Version="*" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" />
+    <PackageReference Include="Newtonsoft.Json" IncludeAssets="compile" />
+    <PackageReference Include="SteamKit2" IncludeAssets="compile" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" IncludeAssets="compile" />
+    <PackageReference Include="System.Composition.AttributedModel" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Collections.Immutable" IncludeAssets="compile" Version="*" />
+    <PackageReference Include="System.Collections.Immutable" IncludeAssets="compile" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchiSteamFarm.Tests/ArchiSteamFarm.Tests.csproj
+++ b/ArchiSteamFarm.Tests/ArchiSteamFarm.Tests.csproj
@@ -4,10 +4,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -7,39 +7,39 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AngleSharp.XPath" Version="1.1.7" />
-    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" Version="5.0.0" />
-    <PackageReference Include="CryptSharpStandard" Version="1.0.0" />
-    <PackageReference Include="Humanizer" Version="2.9.9" />
-    <PackageReference Include="JetBrains.Annotations" Version="2021.1.0" />
-    <PackageReference Include="Markdig.Signed" Version="0.24.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
-    <PackageReference Include="NLog" Version="4.7.9" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.12.0" />
-    <PackageReference Include="SteamKit2" Version="2.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
-    <PackageReference Include="System.Composition" Version="5.0.1" />
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <PackageReference Include="AngleSharp.XPath" />
+    <PackageReference Include="ConfigureAwaitChecker.Analyzer" PrivateAssets="all" />
+    <PackageReference Include="CryptSharpStandard" />
+    <PackageReference Include="Humanizer" />
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="Markdig.Signed" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Nito.AsyncEx.Coordination" />
+    <PackageReference Include="NLog" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
+    <PackageReference Include="SteamKit2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" />
+    <PackageReference Include="System.Composition" />
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="IndexRange" Version="1.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.*" />
+    <PackageReference Include="IndexRange" />
+    <PackageReference Include="Microsoft.AspNetCore.Cors" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
+    <PackageReference Include="Microsoft.AspNetCore.HttpOverrides" />
+    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <PackageReference Include="Microsoft.AspNetCore.WebSockets" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" />
     <Reference Include="System.Net.Http" HintPath="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Net.Http.dll" />
     <Reference Include="System.Security" HintPath="C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Security.dll" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,6 +12,7 @@
     <Deterministic>true</Deterministic>
     <ErrorReport>none</ErrorReport>
     <LangVersion>latest</LangVersion>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NoWarn>1591</NoWarn>
     <Nullable>enable</Nullable>
     <PackageIcon>../resources/ASF.ico</PackageIcon>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,43 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="AngleSharp.XPath" Version="1.1.7" />
+    <PackageVersion Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0" />
+    <PackageVersion Include="CryptSharpStandard" Version="1.0.0" />
+    <PackageVersion Include="Humanizer" Version="2.9.9" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2021.1.0" />
+    <PackageVersion Include="Markdig.Signed" Version="0.24.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
+    <PackageVersion Include="NLog" Version="4.7.9" />
+    <PackageVersion Include="NLog.Web.AspNetCore" Version="4.12.0" />
+    <PackageVersion Include="SteamKit2" Version="2.3.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
+    <PackageVersion Include="System.Composition" Version="5.0.1" />
+    <PackageVersion Include="System.Composition.AttributedModel" Version="5.0.1" />
+    <PackageVersion Include="System.Linq.Async" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageVersion Include="IndexRange" Version="1.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.14" />
+    <PackageVersion Include="System.Collections.Immutable" Version="5.0.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #2316

The issue we're facing right now comes from the fact of desynchronization of packages between different projects. Since I didn't find any way to "fix" the package versions of our plugins to the main ASF project, we'll instead use centralized `Directory.packages.props` which specifies appropriate versions