### PR TITLE
Make plugin initialization happen before the first call to PluginsCore

### DIFF
--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -113,10 +113,6 @@ namespace ArchiSteamFarm.Core {
 				throw new InvalidOperationException(nameof(GlobalConfig));
 			}
 
-			if (!PluginsCore.InitPlugins()) {
-				await Task.Delay(10000).ConfigureAwait(false);
-			}
-
 			WebBrowser = new WebBrowser(ArchiLogger, GlobalConfig.WebProxy, true);
 
 			await UpdateAndRestart().ConfigureAwait(false);

--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -117,8 +117,6 @@ namespace ArchiSteamFarm.Core {
 
 			await UpdateAndRestart().ConfigureAwait(false);
 
-			await PluginsCore.OnASFInitModules(GlobalConfig.AdditionalProperties).ConfigureAwait(false);
-
 			StringComparer botsComparer = await PluginsCore.GetBotsComparer().ConfigureAwait(false);
 
 			InitBotsComparer(botsComparer);

--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -151,6 +151,8 @@ namespace ArchiSteamFarm.Core {
 
 			GlobalConfig = globalConfig;
 
+			await PluginsCore.OnASFInitModules(globalConfig.AdditionalProperties).ConfigureAwait(false);
+
 			// The only purpose of using hashingAlgorithm below is to cut on a potential size of the resource name - paths can be really long, and we almost certainly have some upper limit on the resource name we can allocate
 			// At the same time it'd be the best if we avoided all special characters, such as '/' found e.g. in base64, as we can't be sure that it's not a prohibited character in regards to native OS implementation
 			// Because of that, SHA256 is sufficient for our case, as it generates alphanumeric characters only, and is barely 256-bit long. We don't need any kind of complex cryptography or collision detection here, any hashing algorithm will do, and the shorter the better

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -36,6 +36,7 @@ using ArchiSteamFarm.IPC;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.NLog;
 using ArchiSteamFarm.NLog.Targets;
+using ArchiSteamFarm.Plugins;
 using ArchiSteamFarm.Steam;
 using ArchiSteamFarm.Storage;
 using ArchiSteamFarm.Web;
@@ -139,6 +140,10 @@ namespace ArchiSteamFarm {
 		}
 
 		private static async Task<bool> InitASF() {
+			if (!PluginsCore.InitPlugins()) {
+				await Task.Delay(10000).ConfigureAwait(false);
+			}
+
 			if (!await InitGlobalConfigAndLanguage().ConfigureAwait(false)) {
 				return false;
 			}

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -286,6 +286,8 @@ namespace ArchiSteamFarm {
 				ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 			}
 
+			await PluginsCore.OnASFInitModules(globalConfig.AdditionalProperties).ConfigureAwait(false);
+
 			await ASF.InitGlobalConfig(globalConfig).ConfigureAwait(false);
 
 			// Skip translation progress for English and invariant (such as "C") cultures

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -286,8 +286,6 @@ namespace ArchiSteamFarm {
 				ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 			}
 
-			await PluginsCore.OnASFInitModules(globalConfig.AdditionalProperties).ConfigureAwait(false);
-
 			await ASF.InitGlobalConfig(globalConfig).ConfigureAwait(false);
 
 			// Skip translation progress for English and invariant (such as "C") cultures


### PR DESCRIPTION
The first call is GetCrossProcessSemaphore which happens for global config and global database initialization however plugin initialization happens after that.