### PR TITLE
Add controllers as services

### DIFF
--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -263,6 +263,8 @@ namespace ArchiSteamFarm.IPC {
 				}
 			}
 
+			mvc.AddControllersAsServices();
+
 			// Use latest compatibility version for MVC
 			mvc.SetCompatibilityVersion(CompatibilityVersion.Latest);
 


### PR DESCRIPTION
This will allow injecting ASF controllers or plugins controllers into others (e.g. reusing `CommandController` methods with different APIs).