### PR TITLE
Use ArchiHandler to fetch owned games

### DIFF
--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -254,6 +254,7 @@ namespace ArchiSteamFarm.Steam.Integration {
 			}
 		}
 
+		[Obsolete("Use " + nameof(ArchiHandler) + "." + nameof(ArchiHandler.GetOwnedGames) + " instead")]
 		[PublicAPI]
 		public async Task<Dictionary<uint, string>?> GetMyOwnedGames() {
 			ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningDeprecated, nameof(GetMyOwnedGames), nameof(ArchiHandler) + "." + nameof(ArchiHandler.GetOwnedGames)));
@@ -305,6 +306,7 @@ namespace ArchiSteamFarm.Steam.Integration {
 			return result;
 		}
 
+		[Obsolete("Use " + nameof(ArchiHandler) + "." + nameof(ArchiHandler.GetOwnedGames) + " instead")]
 		[PublicAPI]
 		public async Task<Dictionary<uint, string>?> GetOwnedGames(ulong steamID) {
 			if ((steamID == 0) || !new SteamID(steamID).IsIndividualAccount) {

--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -256,6 +256,8 @@ namespace ArchiSteamFarm.Steam.Integration {
 
 		[PublicAPI]
 		public async Task<Dictionary<uint, string>?> GetMyOwnedGames() {
+			ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningDeprecated, nameof(GetMyOwnedGames), nameof(ArchiHandler) + "." + nameof(ArchiHandler.GetOwnedGames)));
+
 			Uri request = new(SteamCommunityURL, "/my/games?l=english&xml=1");
 
 			XmlDocumentResponse? response = await UrlGetToXmlDocumentWithSession(request, checkSessionPreemptively: false).ConfigureAwait(false);
@@ -308,6 +310,8 @@ namespace ArchiSteamFarm.Steam.Integration {
 			if ((steamID == 0) || !new SteamID(steamID).IsIndividualAccount) {
 				throw new ArgumentOutOfRangeException(nameof(steamID));
 			}
+
+			ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningDeprecated, nameof(GetOwnedGames), nameof(ArchiHandler) + "." + nameof(ArchiHandler.GetOwnedGames)));
 
 			(bool success, string? steamApiKey) = await CachedApiKey.GetValue().ConfigureAwait(false);
 

--- a/ArchiSteamFarm/Steam/Interaction/Commands.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Commands.cs
@@ -481,9 +481,7 @@ namespace ArchiSteamFarm.Steam.Interaction {
 				return null;
 			}
 
-			bool? hasValidApiKey = await Bot.ArchiWebHandler.HasValidApiKey().ConfigureAwait(false);
-
-			Dictionary<uint, string>? gamesOwned = hasValidApiKey.GetValueOrDefault() ? await Bot.ArchiWebHandler.GetOwnedGames(Bot.SteamID).ConfigureAwait(false) : await Bot.ArchiWebHandler.GetMyOwnedGames().ConfigureAwait(false);
+			Dictionary<uint, string>? gamesOwned = await Bot.ArchiHandler.GetOwnedGames(Bot.SteamID).ConfigureAwait(false);
 
 			if (gamesOwned?.Count > 0) {
 				lock (CachedGamesOwned) {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
     <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.0" />
     <PackageVersion Include="NLog" Version="4.7.10" />
     <PackageVersion Include="NLog.Web.AspNetCore" Version="4.12.0" />
-    <PackageVersion Include="SteamKit2" Version="2.3.0" />
+    <PackageVersion Include="SteamKit2" Version="2.4.0-Alpha.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.1.4" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />


### PR DESCRIPTION
This method doesn't require a valid API key and contains all the apps which `ArchiWebHandler.GetOwnedGames` provides. SteamKit update is required due to `skip_unvetted_apps` parameter missing in versions prior to `2.4.0-Alpha.2`.