### PR TITLE
Fix GlobalConfig update via IPC removing IPCPassword

### DIFF
--- a/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
@@ -121,6 +121,10 @@ namespace ArchiSteamFarm.IPC.Controllers.Api {
 
 			request.GlobalConfig.Saving = true;
 
+			if (!request.GlobalConfig.IsIPCPasswordSet && ASF.GlobalConfig.IsIPCPasswordSet) {
+				request.GlobalConfig.IPCPassword = ASF.GlobalConfig.IPCPassword;
+			}
+
 			if (!request.GlobalConfig.IsWebProxyPasswordSet && ASF.GlobalConfig.IsWebProxyPasswordSet) {
 				request.GlobalConfig.WebProxyPassword = ASF.GlobalConfig.WebProxyPassword;
 			}

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -221,9 +221,6 @@ namespace ArchiSteamFarm.Storage {
 		[JsonProperty(Required = Required.DisallowNull)]
 		public bool IPC { get; private set; } = DefaultIPC;
 
-		[JsonProperty]
-		public string? IPCPassword { get; private set; } = DefaultIPCPassword;
-
 		[JsonProperty(Required = Required.DisallowNull)]
 		public ArchiCryptoHelper.EHashingMethod IPCPasswordFormat { get; private set; } = DefaultIPCPasswordFormat;
 
@@ -281,7 +278,20 @@ namespace ArchiSteamFarm.Storage {
 			set;
 		}
 
+		[JsonProperty]
+		public string? IPCPassword {
+			get => BackingIPCPassword;
+
+			set {
+				IsIPCPasswordSet = true;
+				BackingIPCPassword = value;
+			}
+		}
+
+		internal bool IsIPCPasswordSet { get; private set; }
+
 		internal bool IsWebProxyPasswordSet { get; private set; }
+
 		internal bool Saving { get; set; }
 
 		[JsonProperty]
@@ -293,6 +303,8 @@ namespace ArchiSteamFarm.Storage {
 				BackingWebProxyPassword = value;
 			}
 		}
+
+		private string? BackingIPCPassword = DefaultIPCPassword;
 
 		private WebProxy? BackingWebProxy;
 		private string? BackingWebProxyPassword = DefaultWebProxyPassword;


### PR DESCRIPTION
Currently updating `GlobalConfig` via the respective IPC endpoint resets `IPCPassword` to its default value. This merge request attempts to fix the issue.