### PR TITLE
Don't serialize AdditionalProperties for Asset

### DIFF
--- a/ArchiSteamFarm/Steam/Data/Asset.cs
+++ b/ArchiSteamFarm/Steam/Data/Asset.cs
@@ -88,7 +88,7 @@ namespace ArchiSteamFarm.Steam.Data {
 		[PublicAPI]
 		public EType Type { get; internal set; }
 
-		[JsonExtensionData]
+		[JsonExtensionData(WriteData = false)]
 		internal Dictionary<string, JToken>? AdditionalProperties { private get; set; }
 
 		[JsonProperty(PropertyName = "amount", Required = Required.Always)]

--- a/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
+++ b/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
@@ -191,7 +191,7 @@ namespace ArchiSteamFarm.Steam.Data {
 				}
 			}
 
-			[JsonExtensionData]
+			[JsonExtensionData(WriteData = false)]
 			internal Dictionary<string, JToken>? AdditionalProperties {
 				get;
 				[UsedImplicitly]


### PR DESCRIPTION
This will fix sending more data than actually necessary to Steam when sending trade offer (also prevents errors for trades with lots of items, etc. tens of thousands).