### PR TITLE
Remove two unnecessary context switches

### DIFF
--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -1158,7 +1158,7 @@ namespace ArchiSteamFarm.Steam {
 			return ((productInfoResultSet.Complete && !productInfoResultSet.Failed) || optimisticDiscovery ? appID : 0, DateTime.MinValue, true);
 		}
 
-		internal async Task<HashSet<uint>?> GetMarketableAppIDs() => await ArchiWebHandler.GetAppList().ConfigureAwait(false);
+		internal Task<HashSet<uint>?> GetMarketableAppIDs() => ArchiWebHandler.GetAppList();
 
 		internal async Task<Dictionary<uint, (uint ChangeNumber, ImmutableHashSet<uint>? AppIDs)>?> GetPackagesData(IReadOnlyCollection<uint> packageIDs) {
 			if ((packageIDs == null) || (packageIDs.Count == 0)) {

--- a/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
@@ -52,7 +52,7 @@ namespace ArchiSteamFarm.Steam.Integration {
 			);
 		}
 
-		public async ValueTask DisposeAsync() => await SaleEventTimer.DisposeAsync().ConfigureAwait(false);
+		public ValueTask DisposeAsync() => SaleEventTimer.DisposeAsync();
 
 		private async void ExploreDiscoveryQueue(object? state = null) {
 			if (!Bot.IsConnectedAndLoggedOn) {


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### Changed functionality

Two methods that previously created a new task now just return the inner task without awaiting it. This takes some pressure off the runtime, as it is one context switch less each time.