### PR TITLE
Warn about insecure passwords

### DIFF
--- a/ArchiSteamFarm/Localization/Strings.Designer.cs
+++ b/ArchiSteamFarm/Localization/Strings.Designer.cs
@@ -992,7 +992,7 @@ namespace ArchiSteamFarm.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No bots are defined. Did you forget to configure your ASF?.
+        ///   Looks up a localized string similar to No bots are defined. Did you forget to configure your ASF? Follow &apos;setting up&apos; guide on the wiki if you&apos;re confused..
         /// </summary>
         public static string ErrorNoBotsDefined {
             get {
@@ -1631,6 +1631,15 @@ namespace ArchiSteamFarm.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Your {0} password is saved in plaintext. Please consider encrypting it!.
+        /// </summary>
+        public static string WarningPasswordSavedAsPlaintext {
+            get {
+                return ResourceManager.GetString("WarningPasswordSavedAsPlaintext", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You&apos;re using a version that is newer than the latest released version for your update channel. Please note that pre-release versions are meant for users who know how to report bugs, deal with issues and give feedback - no technical support will be given..
         /// </summary>
         public static string WarningPreReleaseVersion {
@@ -1672,6 +1681,24 @@ namespace ArchiSteamFarm.Localization {
         public static string WarningUnsupportedEnvironment {
             get {
                 return ResourceManager.GetString("WarningUnsupportedEnvironment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your IPC password is weak. Please consider choosing a stronger one! You can find guidelines on strong passwords in our wiki!.
+        /// </summary>
+        public static string WarningWeakIPCPassword {
+            get {
+                return ResourceManager.GetString("WarningWeakIPCPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your Steam password for &apos;{0}&apos; is weak. Please consider changing it to a stronger one! You can find guidelines on strong passwords in our wiki!.
+        /// </summary>
+        public static string WarningWeakSteamPassword {
+            get {
+                return ResourceManager.GetString("WarningWeakSteamPassword", resourceCulture);
             }
         }
         

--- a/ArchiSteamFarm/Localization/Strings.resx
+++ b/ArchiSteamFarm/Localization/Strings.resx
@@ -699,4 +699,13 @@ Process uptime: {1}</value>
 		<value>{0} config file will be migrated to the latest syntax...</value>
 		<comment>{0} will be replaced with the relative path to the affected config file</comment>
 	</data>
+    <data name="WarningPasswordSavedAsPlaintext" xml:space="preserve">
+        <value>Your {0} password is saved in plaintext. Please consider encrypting it!</value>
+    </data>
+	<data name="WarningWeakIPCPassword" xml:space="preserve">
+		<value>Your IPC password is weak. Please consider choosing a stronger one! You can find guidelines on strong passwords in our wiki!</value>
+	</data>
+	<data name="WarningWeakSteamPassword" xml:space="preserve">
+		<value>Your Steam password for '{0}' is weak. Please consider changing it to a stronger one! You can find guidelines on strong passwords in our wiki!</value>
+	</data>
 </root>

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -580,6 +580,21 @@ namespace ArchiSteamFarm.Steam.Storage {
 				return (null, null);
 			}
 
+			if (botConfig.PasswordFormat == ArchiCryptoHelper.ECryptoMethod.PlainText) {
+				ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningPasswordSavedAsPlaintext, nameof(Steam)));
+
+				if (botConfig.IsSteamPasswordSet && botConfig.SteamPassword != null) {
+					string[] disallowedValues = botConfig.IsSteamLoginSet switch {
+						true => new[] { "account", botConfig.SteamLogin! },
+						false => new[] { "account" }
+					};
+
+					if (Utilities.IsWeakPassword(botConfig.SteamPassword, disallowedValues)) {
+						ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningWeakSteamPassword, botConfig.IsSteamLoginSet ? botConfig.SteamLogin! : filePath));
+					}
+				}
+			}
+
 			if (!Program.ConfigMigrate) {
 				return (botConfig, null);
 			}

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -582,16 +582,16 @@ namespace ArchiSteamFarm.Steam.Storage {
 
 			if (botConfig.PasswordFormat == ArchiCryptoHelper.ECryptoMethod.PlainText) {
 				ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningPasswordSavedAsPlaintext, nameof(Steam)));
+			}
 
-				if (botConfig.IsSteamPasswordSet && botConfig.SteamPassword != null) {
-					string[] disallowedValues = botConfig.IsSteamLoginSet switch {
-						true => new[] { "account", botConfig.SteamLogin! },
-						false => new[] { "account" }
-					};
+			if (botConfig.IsSteamPasswordSet && botConfig.DecryptedSteamPassword != null) {
+				string[] disallowedValues = botConfig.IsSteamLoginSet switch {
+					true => new[] { "account", botConfig.SteamLogin! },
+					false => new[] { "account" }
+				};
 
-					if (Utilities.IsWeakPassword(botConfig.SteamPassword, disallowedValues)) {
-						ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningWeakSteamPassword, botConfig.IsSteamLoginSet ? botConfig.SteamLogin! : filePath));
-					}
+				if (Utilities.IsWeakPassword(botConfig.DecryptedSteamPassword, disallowedValues)) {
+					ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningWeakSteamPassword, botConfig.IsSteamLoginSet ? botConfig.SteamLogin! : filePath));
 				}
 			}
 

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -504,6 +504,16 @@ namespace ArchiSteamFarm.Storage {
 				return (null, null);
 			}
 
+			if (globalConfig.IPCPasswordFormat == ArchiCryptoHelper.EHashingMethod.PlainText) {
+				ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningPasswordSavedAsPlaintext, nameof(IPC)));
+
+				if (globalConfig.IsIPCPasswordSet && globalConfig.IPCPassword != null) {
+					if (Utilities.IsWeakPassword(globalConfig.IPCPassword, "ipc", "api", "gui", "asf-ui")) {
+						ASF.ArchiLogger.LogGenericWarning(Strings.WarningWeakIPCPassword);
+					}
+				}
+			}
+
 			if (!Program.ConfigMigrate) {
 				return (globalConfig, null);
 			}


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

When loading a configuration file from disk, warnings about password security are logged, if the user:
- saved their IPC password in plaintext
- saved their Steam password in plaintext
- has a weak IPC password
- has a weak Steam password

Passwords are weak if:
- they contain 3 or more sequential characters (e.g. "abc", "123")
- they contain 3 or more repetitive characters (e.g. "aaa", "111")
- they contain less than 10 characters
- they contain the phrases "asf", "archi", "steam", "achisteamfarm", "password"

Additionally IPC passwords are considered weak if they contain the phrases "ipc", "api", "gui" or "asf-ui".

Similarly Steam passwords are weak if they contain the phrase "account" or the bots Steam username.

Disallowed phrases are checked ignoring upper-/lower-casing.

--- 

I derived those guidelines directly from [NIST publication 800-63b](https://pages.nist.gov/800-63-3/sp800-63b.html#sec5) (section 5: Authenticator and Verifier Requirements; especially section 5.1.1.2: Memorized Secret Verifiers)

> Verifiers SHALL require subscriber-chosen memorized secrets to be at least 8 characters in length

I've taken the liberty to extend this to 10 characters

> When processing requests to establish and change memorized secrets, verifiers SHALL compare the prospective secrets against a list that contains values known to be commonly-used, expected, or compromised. For example, the list MAY include, but is not limited to:
> [...]
> - Repetitive or sequential characters (e.g. ‘aaaaaa’, ‘1234abcd’)
> - Context-specific words, such as the name of the service, the username, and derivatives thereof

> Verifiers SHOULD offer guidance to the subscriber, such as a password-strength meter [Meters], to assist the user in choosing a strong memorized secret

The warnings in the log should cover this point. Additionally the warnings about weak passwords mention our wiki, where we should outline why ASF complains about passwords.

> Verifiers SHALL store memorized secrets in a form that is resistant to offline attacks

Since we cannot force the user to encrypt/hash their passwords (at least not without getting a lot of new questions on our discord server), we can only warn them about this. The new log statements should cover this.

> For PBKDF2, the cost factor is an iteration count: the more times the PBKDF2 function is iterated, the longer it takes to compute the password hash. Therefore, the iteration count SHOULD be as large as verification server performance will allow, typically at least 10,000 iterations.

We currently use exactly 10,000 iterations. Technically we are covering the absolute minimum, but personally I would like to go a bit higher.

> In addition, verifiers SHOULD perform an additional iteration of a key derivation function using a salt value that is secret and known only to the verifier.

Already covering this one, but...

We are not covering the part about [approved random bit generators](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf), but at least we are covering the 112 bits as of the date of the publication (exactly 112 bits) with our default value. We also can't really store the salt independantly (e.g. on a "specialized device like a hardware security module" [that's a funny requirement by the NIST guys]), so I think we should be fine here too.

## Additional info

Thank you for considering the inclusion of this merge request!