### PR TITLE
Use Madness via global usings

### DIFF
--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/ExamplePlugin.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/ExamplePlugin.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Composition;

--- a/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/GlobalCache.cs
+++ b/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/GlobalCache.cs
@@ -19,10 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/SteamTokenDumperPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/SteamTokenDumperPlugin.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm.Tests/Bot.cs
+++ b/ArchiSteamFarm.Tests/Bot.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -30,16 +30,6 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<Using Include="Microsoft.AspNetCore.Hosting.IHostingEnvironment" Alias="IWebHostEnvironment" />
-		<Using Include="Microsoft.AspNetCore.Hosting.IWebHost" Alias="IHost" />
-		<Using Include="Microsoft.AspNetCore.Hosting.WebHostBuilder" Alias="HostBuilder" />
-		<Using Include="Microsoft.AspNetCore.Mvc" />
-		<Using Include="Microsoft.AspNetCore.Mvc.MvcJsonOptions" Alias="MvcNewtonsoftJsonOptions" />
-		<Using Include="Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder" Alias="IMvcBuilder" />
-		<Using Include="Newtonsoft.Json.Converters" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="Microsoft.AspNetCore.Cors" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
 		<PackageReference Include="Microsoft.AspNetCore.HttpOverrides" />

--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -30,7 +30,16 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageReference Include="JustArchiNET.Madness" />
+		<Using Include="Microsoft.AspNetCore.Hosting.IHostingEnvironment" Alias="IWebHostEnvironment" />
+		<Using Include="Microsoft.AspNetCore.Hosting.IWebHost" Alias="IHost" />
+		<Using Include="Microsoft.AspNetCore.Hosting.WebHostBuilder" Alias="HostBuilder" />
+		<Using Include="Microsoft.AspNetCore.Mvc" />
+		<Using Include="Microsoft.AspNetCore.Mvc.MvcJsonOptions" Alias="MvcNewtonsoftJsonOptions" />
+		<Using Include="Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder" Alias="IMvcBuilder" />
+		<Using Include="Newtonsoft.Json.Converters" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
 		<PackageReference Include="Microsoft.AspNetCore.Cors" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
 		<PackageReference Include="Microsoft.AspNetCore.HttpOverrides" />

--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -19,12 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-using OperatingSystem = JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem;
-using Path = JustArchiNET.Madness.PathMadness.Path;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -19,17 +19,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using OperatingSystem = JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem;
-#else
-using System.Runtime.Versioning;
-#endif
 using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Principal;
 using System.Text;

--- a/ArchiSteamFarm/Core/Statistics.cs
+++ b/ArchiSteamFarm/Core/Statistics.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/Helpers/ArchiCryptoHelper.cs
+++ b/ArchiSteamFarm/Helpers/ArchiCryptoHelper.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using OperatingSystem = JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
+++ b/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using OperatingSystem = JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem;
-#endif
 #if TARGET_GENERIC || TARGET_WINDOWS
 using System.Security.AccessControl;
 #endif

--- a/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
+++ b/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
@@ -184,7 +184,7 @@ namespace ArchiSteamFarm.Helpers {
 
 #if TARGET_GENERIC || !TARGET_WINDOWS
 				if (OperatingSystem.IsFreeBSD() || OperatingSystem.IsLinux() || OperatingSystem.IsMacOS()) {
-					OS.UnixSetFileAccess(directoryPath, OS.EUnixPermission.Combined777);
+					OS.UnixSetFileAccess(directoryPath!, OS.EUnixPermission.Combined777);
 				}
 #endif
 			}

--- a/ArchiSteamFarm/Helpers/SerializableFile.cs
+++ b/ArchiSteamFarm/Helpers/SerializableFile.cs
@@ -19,12 +19,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using System.IO;
-#endif
 using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Core;

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -19,12 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using Microsoft.Extensions.Hosting;
-#endif
 using System;
 using System.IO;
 using System.Threading.Tasks;
@@ -35,6 +29,7 @@ using ArchiSteamFarm.NLog;
 using ArchiSteamFarm.NLog.Targets;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -44,11 +39,7 @@ namespace ArchiSteamFarm.IPC {
 	internal static class ArchiKestrel {
 		internal static HistoryTarget? HistoryTarget { get; private set; }
 
-#if NETFRAMEWORK
-		private static IWebHost? KestrelWebHost;
-#else
 		private static IHost? KestrelWebHost;
-#endif
 
 		internal static void OnNewHistoryTarget(HistoryTarget? historyTarget = null) {
 			if (HistoryTarget != null) {
@@ -70,11 +61,7 @@ namespace ArchiSteamFarm.IPC {
 			ASF.ArchiLogger.LogGenericInfo(Strings.IPCStarting);
 
 			// The order of dependency injection matters, pay attention to it
-#if NETFRAMEWORK
-			WebHostBuilder builder = new();
-#else
 			HostBuilder builder = new();
-#endif
 
 			string customDirectory = Path.Combine(Directory.GetCurrentDirectory(), SharedInfo.WebsiteDirectory);
 			string websiteDirectory = Directory.Exists(customDirectory) ? customDirectory : Path.Combine(AppContext.BaseDirectory, SharedInfo.WebsiteDirectory);
@@ -144,11 +131,7 @@ namespace ArchiSteamFarm.IPC {
 			Logging.InitHistoryLogger();
 
 			// Start the server
-#if NETFRAMEWORK
-			IWebHost? kestrelWebHost = null;
-#else
 			IHost? kestrelWebHost = null;
-#endif
 
 			try {
 				kestrelWebHost = builder.Build();

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -19,6 +19,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if NETFRAMEWORK
+using IHost = Microsoft.AspNetCore.Hosting.IWebHost;
+using HostBuilder = Microsoft.AspNetCore.Hosting.WebHostBuilder;
+#endif
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ArchiSteamFarm/IPC/Controllers/Api/BotController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/BotController.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;

--- a/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/IPC/Controllers/Api/TwoFactorAuthenticationController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/TwoFactorAuthenticationController.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
+++ b/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
@@ -19,6 +19,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if NETFRAMEWORK
+using MvcNewtonsoftJsonOptions = Microsoft.AspNetCore.Mvc.MvcJsonOptions;
+#endif
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;

--- a/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
+++ b/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
@@ -70,11 +67,7 @@ namespace ArchiSteamFarm.IPC.Integration {
 		}
 
 		[UsedImplicitly]
-#if NETFRAMEWORK
-		public async Task InvokeAsync(HttpContext context, IOptions<MvcJsonOptions> jsonOptions) {
-#else
 		public async Task InvokeAsync(HttpContext context, IOptions<MvcNewtonsoftJsonOptions> jsonOptions) {
-#endif
 			if (context == null) {
 				throw new ArgumentNullException(nameof(context));
 			}

--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -19,11 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Converters;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -57,11 +52,7 @@ namespace ArchiSteamFarm.IPC {
 		public Startup(IConfiguration configuration) => Configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
 		[UsedImplicitly]
-#if NETFRAMEWORK
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env) {
-#else
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env) {
-#endif
 			if (app == null) {
 				throw new ArgumentNullException(nameof(app));
 			}
@@ -242,11 +233,7 @@ namespace ArchiSteamFarm.IPC {
 			// Add support for localization
 			services.AddLocalization();
 
-#if NETFRAMEWORK
-			services.Configure<RequestLocalizationOptions>(
-#else
 			services.AddRequestLocalization(
-#endif
 				static options => {
 					// We do not set the DefaultRequestCulture here, because it will default to Thread.CurrentThread.CurrentCulture in this case, which is set when loading GlobalConfig
 
@@ -335,11 +322,7 @@ namespace ArchiSteamFarm.IPC {
 			services.AddSwaggerGenNewtonsoftSupport();
 
 			// We need MVC for /Api, but we're going to use only a small subset of all available features
-#if NETFRAMEWORK
-			IMvcCoreBuilder mvc = services.AddMvcCore();
-#else
 			IMvcBuilder mvc = services.AddControllers();
-#endif
 
 			// Add support for controllers declared in custom plugins
 			if (PluginsCore.ActivePlugins?.Count > 0) {

--- a/ArchiSteamFarm/IPC/Startup.cs
+++ b/ArchiSteamFarm/IPC/Startup.cs
@@ -19,6 +19,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if NETFRAMEWORK
+using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json.Converters;
+using IWebHostEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+using IMvcBuilder = Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ArchiSteamFarm/IPC/WebUtilities.cs
+++ b/ArchiSteamFarm/IPC/WebUtilities.cs
@@ -20,7 +20,8 @@
 // limitations under the License.
 
 #if NETFRAMEWORK
-using JustArchiNET.Madness;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
 #endif
 using System;
 using System.IO;
@@ -32,6 +33,23 @@ using Newtonsoft.Json;
 
 namespace ArchiSteamFarm.IPC {
 	internal static class WebUtilities {
+#if NETFRAMEWORK
+		internal static IMvcBuilder AddControllers(this IServiceCollection services) {
+			if (services == null) {
+				throw new ArgumentNullException(nameof(services));
+			}
+
+			return services.AddMvcCore();
+		}
+
+		internal static IServiceCollection AddRequestLocalization(this IServiceCollection services, Action<RequestLocalizationOptions> action) {
+			if (services == null) {
+				throw new ArgumentNullException(nameof(services));
+			}
+
+			return services.Configure(action);
+		}
+#endif
 		internal static string? GetUnifiedName(this Type type) {
 			if (type == null) {
 				throw new ArgumentNullException(nameof(type));

--- a/ArchiSteamFarm/IPC/WebUtilities.cs
+++ b/ArchiSteamFarm/IPC/WebUtilities.cs
@@ -34,7 +34,7 @@ using Newtonsoft.Json;
 namespace ArchiSteamFarm.IPC {
 	internal static class WebUtilities {
 #if NETFRAMEWORK
-		internal static IMvcBuilder AddControllers(this IServiceCollection services) {
+		internal static IMvcCoreBuilder AddControllers(this IServiceCollection services) {
 			if (services == null) {
 				throw new ArgumentNullException(nameof(services));
 			}

--- a/ArchiSteamFarm/NLog/ArchiLogger.cs
+++ b/ArchiSteamFarm/NLog/ArchiLogger.cs
@@ -19,14 +19,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using File = System.IO.File;
-#endif
 using System;
 using System.Globalization;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -19,11 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-using Path = JustArchiNET.Madness.PathMadness.Path;
-#endif
 using System;
 using System.Collections;
 using System.Collections.Concurrent;

--- a/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
+++ b/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/Steam/Cards/Game.cs
+++ b/ArchiSteamFarm/Steam/Cards/Game.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using HashCode = JustArchiNET.Madness.HashCodeMadness.HashCode;
-#endif
 using System;
 using Newtonsoft.Json;
 

--- a/ArchiSteamFarm/Steam/Exchange/Trading.cs
+++ b/ArchiSteamFarm/Steam/Exchange/Trading.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/Steam/Integration/SteamChatMessage.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamChatMessage.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Immutable;
 using System.Globalization;

--- a/ArchiSteamFarm/Steam/Interaction/Actions.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Actions.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/ArchiSteamFarm/Steam/Interaction/Commands.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Commands.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using String = JustArchiNET.Madness.StringMadness.String;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/ArchiSteamFarm/Steam/SteamKit2/ServerRecordEndPoint.cs
+++ b/ArchiSteamFarm/Steam/SteamKit2/ServerRecordEndPoint.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using HashCode = JustArchiNET.Madness.HashCodeMadness.HashCode;
-#endif
 using System;
 using System.ComponentModel;
 using Newtonsoft.Json;

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -19,18 +19,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using System.IO;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;

--- a/ArchiSteamFarm/Steam/Storage/BotDatabase.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotDatabase.cs
@@ -19,15 +19,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using System.IO;
-#endif
 using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Collections;

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -19,17 +19,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using System.IO;
-#endif
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
 using System.Net;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Core;

--- a/ArchiSteamFarm/Storage/GlobalDatabase.cs
+++ b/ArchiSteamFarm/Storage/GlobalDatabase.cs
@@ -19,17 +19,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-using File = JustArchiNET.Madness.FileMadness.File;
-#else
-using System.IO;
-#endif
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/ArchiSteamFarm/Web/Responses/StreamResponse.cs
+++ b/ArchiSteamFarm/Web/Responses/StreamResponse.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.IO;
 using System.Net.Http;

--- a/ArchiSteamFarm/Web/WebBrowser.cs
+++ b/ArchiSteamFarm/Web/WebBrowser.cs
@@ -19,9 +19,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETFRAMEWORK
-using JustArchiNET.Madness;
-#endif
 using System;
 using System.Buffers;
 using System.Collections.Generic;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,6 +30,16 @@
 		<TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
 	</PropertyGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+		<PackageReference Include="JustArchiNET.Madness" />
+		<Using Include="JustArchiNET.Madness" />
+		<Using Include="JustArchiNET.Madness.OperatingSystemMadness.OperatingSystem" Alias="OperatingSystem" />
+		<Using Include="JustArchiNET.Madness.FileMadness.File" Alias="File" />
+		<Using Include="JustArchiNET.Madness.PathMadness.Path" Alias="Path" />
+		<Using Include="JustArchiNET.Madness.HashCodeMadness.HashCode" Alias="HashCode" />
+		<Using Include="JustArchiNET.Madness.StringMadness.String" Alias="String" />
+	</ItemGroup>
+
 	<PropertyGroup Condition="'$(ASFVariant)' != ''">
 		<DefineConstants>$(DefineConstants);ASF_VARIANT_$(ASFVariant.Replace('-', '_').ToUpperInvariant())</DefineConstants>
 	</PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageVersion Include="JustArchiNET.Madness" Version="2.0.0-alpha1" />
+		<PackageVersion Include="JustArchiNET.Madness" Version="2.0.0-alpha2" />
 		<PackageVersion Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

I've made use of the global usings that came with `net6.0` and removed a lot of `#if NETFRAMEWORK` blocks in the code to improve readability.

## Additional info

Thank you in advance for considering the inclusion of this merge request.
