### PR TITLE
Split global statistics into per-bot RemoteConnection

### DIFF
--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -35,6 +35,7 @@ using ArchiSteamFarm.IPC.Integration;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.Steam.Data;
 using ArchiSteamFarm.Steam.Integration;
+using ArchiSteamFarm.Storage;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -603,7 +604,18 @@ public sealed class BotConfig {
 				break;
 		}
 
+		// TODO: Pending removal, Statistics -> RemoteCommunication migration
+		if ((ASF.GlobalConfig?.Statistics == false) && (botConfig.RemoteCommunication == DefaultRemoteCommunication)) {
+			botConfig.RemoteCommunication = ERemoteCommunication.None;
+		}
+
 		if (!Program.ConfigMigrate) {
+			// TODO: Pending removal, warning for people that disabled config migrate, they need to migrate themselves
+			if (ASF.GlobalConfig?.Statistics == false) {
+				ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningFailedWithError, nameof(Program.ConfigMigrate)));
+				ASF.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningDeprecated, nameof(GlobalConfig.Statistics), nameof(RemoteCommunication)));
+			}
+
 			return (botConfig, null);
 		}
 

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -81,6 +81,9 @@ public sealed class BotConfig {
 	public const ERedeemingPreferences DefaultRedeemingPreferences = ERedeemingPreferences.None;
 
 	[PublicAPI]
+	public const ERemoteCommunication DefaultRemoteCommunication = ERemoteCommunication.All;
+
+	[PublicAPI]
 	public const bool DefaultSendOnFarmingFinished = false;
 
 	[PublicAPI]
@@ -194,6 +197,9 @@ public sealed class BotConfig {
 
 	[JsonProperty(Required = Required.DisallowNull)]
 	public ERedeemingPreferences RedeemingPreferences { get; private set; } = DefaultRedeemingPreferences;
+
+	[JsonProperty(Required = Required.DisallowNull)]
+	public ERemoteCommunication RemoteCommunication { get; private set; } = DefaultRemoteCommunication;
 
 	[JsonProperty(Required = Required.DisallowNull)]
 	public bool SendOnFarmingFinished { get; private set; } = DefaultSendOnFarmingFinished;
@@ -350,6 +356,9 @@ public sealed class BotConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeRedeemingPreferences() => !Saving || (RedeemingPreferences != DefaultRedeemingPreferences);
+
+	[UsedImplicitly]
+	public bool ShouldSerializeRemoteCommunication() => !Saving || (RemoteCommunication != DefaultRemoteCommunication);
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSendOnFarmingFinished() => !Saving || (SendOnFarmingFinished != DefaultSendOnFarmingFinished);
@@ -660,6 +669,15 @@ public sealed class BotConfig {
 		KeepMissingGames = 4,
 		AssumeWalletKeyOnBadActivationCode = 8,
 		All = Forwarding | Distributing | KeepMissingGames | AssumeWalletKeyOnBadActivationCode
+	}
+
+	[Flags]
+	public enum ERemoteCommunication : byte {
+		None = 0,
+		SteamGroup = 1,
+		TradeMatcher = 2,
+		PublicListing = 4,
+		All = SteamGroup | TradeMatcher | PublicListing
 	}
 
 	[Flags]

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -100,9 +100,6 @@ public sealed class GlobalConfig {
 	public const EOptimizationMode DefaultOptimizationMode = EOptimizationMode.MaxPerformance;
 
 	[PublicAPI]
-	public const bool DefaultStatistics = true;
-
-	[PublicAPI]
 	public const string? DefaultSteamMessagePrefix = "/me ";
 
 	[PublicAPI]
@@ -259,9 +256,6 @@ public sealed class GlobalConfig {
 	[JsonProperty(Required = Required.DisallowNull)]
 	public EOptimizationMode OptimizationMode { get; private set; } = DefaultOptimizationMode;
 
-	[JsonProperty(Required = Required.DisallowNull)]
-	public bool Statistics { get; private set; } = DefaultStatistics;
-
 	[JsonProperty]
 	[MaxLength(SteamChatMessage.MaxMessagePrefixBytes / SteamChatMessage.ReservedEscapeMessageBytes)]
 	public string? SteamMessagePrefix { get; private set; } = DefaultSteamMessagePrefix;
@@ -397,9 +391,6 @@ public sealed class GlobalConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSSteamOwnerID() => !Saving;
-
-	[UsedImplicitly]
-	public bool ShouldSerializeStatistics() => !Saving || (Statistics != DefaultStatistics);
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSteamMessagePrefix() => !Saving || (SteamMessagePrefix != DefaultSteamMessagePrefix);

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -297,6 +297,10 @@ public sealed class GlobalConfig {
 
 	internal bool Saving { get; set; }
 
+	// TODO: Pending removal, Statistics property which got changed into RemoteConnection
+	[JsonProperty(Required = Required.DisallowNull)]
+	internal bool Statistics { get; private set; } = true;
+
 	[JsonProperty]
 	internal string? WebProxyPassword {
 		get => BackingWebProxyPassword;
@@ -391,6 +395,12 @@ public sealed class GlobalConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSSteamOwnerID() => !Saving;
+
+	// TODO: Pending removal, Statistics property which got changed into RemoteConnection, we never serialize it after update
+#pragma warning disable CA1822 // We can't mark it as static
+	[UsedImplicitly]
+	public bool ShouldSerializeStatistics() => false;
+#pragma warning restore CA1822 // We can't mark it as static
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSteamMessagePrefix() => !Saving || (SteamMessagePrefix != DefaultSteamMessagePrefix);


### PR DESCRIPTION
Summary of changes:
- Removed `Statistics` property from global ASF config
- Bot configs now include `RemoteConnection` property which allows to enable, independently from each other: Steam group, ASF STM trade matching and ASF STM public listing
- Default is set to same logic as before (`All`)
- Added migration for old `Statistics`, this is a simple mapping of `false -> None`, as `true` remains the default

I'm thinking whether we need standalone setting for checking ASF checksums when updating, but I guess this should be mandatory if somebody enabled auto-updates, therefore we shouldn't allow people to turn it off, for their own security, we don't want a potential hacker to upload malware remotely to people's computers. If they don't want that communication, they can already disable auto-updates.