### PR TITLE
Correctly detect steam deck keyboard skins

### DIFF
--- a/ArchiSteamFarm/Steam/Data/Asset.cs
+++ b/ArchiSteamFarm/Steam/Data/Asset.cs
@@ -256,6 +256,7 @@ public sealed class Asset {
 		ChatEffect,
 		MiniProfileBackground,
 		AvatarProfileFrame,
-		AnimatedAvatar
+		AnimatedAvatar,
+		KeyboardSkin
 	}
 }

--- a/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
+++ b/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
@@ -180,6 +180,8 @@ internal sealed class InventoryResponse : ResultResponse {
 									return Asset.EType.AvatarProfileFrame;
 								case "item_class_15":
 									return Asset.EType.AnimatedAvatar;
+								case "item_class_16":
+									return Asset.EType.KeyboardSkin;
 								default:
 									ASF.ArchiLogger.LogGenericError(string.Format(CultureInfo.CurrentCulture, Strings.WarningUnknownValuePleaseReport, nameof(tag.Value), tag.Value));
 


### PR DESCRIPTION
## Checklist


- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

Asset type 16 is now detected correctly as a `Asset.EType.KeyboardSkin`, which is also added with this merge request.

## Additional info

Found during active matching and reported by [Toff](https://steamcommunity.com/id/toffmonster) over in our Steam group. I also found it in my logs.

Examples can be found in [this](https://steamcommunity.com/inventory/76561198026039547/753/6?count=5000&l=english) inventory ([this](https://steamcommunity.com/id/rysanlos/) Steam profile). For posterity I've copied and formatted the relevant part out of the JSON structure:

```json
{
	"category":"item_class",
	"internal_name":"item_class_16",
	"localized_category_name":"Item Type",
	"localized_tag_name":"Keyboard Skin"
}
```

<details>
<summary>Slightly bigger part of the JSON structure</summary>

```json
{
	"appid":753,
	"classid":"4772204075",
	"instanceid":"3865004543",
	"currency":0,
	"background_color":"",
	"icon_url":"-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxH5rd9eDAjcFyv45SRYAFMIcKL_PArgVSL403ulRUWEndVKv8gZiGAQ0kaldWs7-keFJjgaueIDtA7YrlltXSz6SmNeyIxTNTv8Z03euQpNr0iwb6ux07Cls3LMY",
	"icon_url_large":"-9a81dlWLwJ2UUGcVs_nsVtzdOEdtWwKGZZLQHTxH5rd9eDAjcFyv45SRYAFMIcKL_PArgVSL403ulRUWEndVKv8gZiGAQ0kalwEsuikcl8x0vCbc20Q6N20ltLZz_SjZ-KFxWoEupImiOrEptr3iVf6ux07aFgxRJQ",
	"descriptions":[
		{
			"value":""
		}
	],
	"tradable":0,
	"name":"Totally Tubular",
	"type":"Steam Deck Keyboard Skin",
	"market_name":"Totally Tubular",
	"market_hash_name":"1675200-Totally Tubular",
	"market_fee_app":1675200,
	"commodity":1,
	"market_tradable_restriction":7,
	"market_marketable_restriction":7,
	"marketable":0,
	"tags":[
		{
			"category":"droprate",
			"internal_name":"droprate_0",
			"localized_category_name":"Rarity",
			"localized_tag_name":"Common"
		},
		{
			"category":"Game",
			"internal_name":"app_1675200",
			"localized_category_name":"Game",
			"localized_tag_name":"Steam Deck"
		},
		{
			"category":"item_class",
			"internal_name":"item_class_16",
			"localized_category_name":"Item Type",
			"localized_tag_name":"Keyboard Skin"
		}
	]
}
```
</details>

Thank you very much for considering the inclusion of this merge request.