### PR TITLE
Simplify LogNullError calls

### DIFF
--- a/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/GlobalCache.cs
+++ b/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/GlobalCache.cs
@@ -120,7 +120,7 @@ internal sealed class GlobalCache : SerializableFile {
 		}
 
 		if (globalCache == null) {
-			ASF.ArchiLogger.LogNullError(nameof(globalCache));
+			ASF.ArchiLogger.LogNullError(globalCache);
 
 			return null;
 		}

--- a/ArchiSteamFarm/Collections/FixedSizeConcurrentQueue.cs
+++ b/ArchiSteamFarm/Collections/FixedSizeConcurrentQueue.cs
@@ -35,7 +35,7 @@ internal sealed class FixedSizeConcurrentQueue<T> : IEnumerable<T> {
 
 		set {
 			if (value == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}

--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -263,7 +263,7 @@ public static class ASF {
 			}
 
 			if (binaryAsset.DownloadURL == null) {
-				ArchiLogger.LogNullError(nameof(binaryAsset.DownloadURL));
+				ArchiLogger.LogNullError(binaryAsset.DownloadURL);
 
 				return null;
 			}
@@ -973,7 +973,7 @@ public static class ASF {
 			string fileName = Path.GetFileName(file);
 
 			if (string.IsNullOrEmpty(fileName)) {
-				ArchiLogger.LogNullError(nameof(fileName));
+				ArchiLogger.LogNullError(fileName);
 
 				return false;
 			}
@@ -981,7 +981,7 @@ public static class ASF {
 			string relativeFilePath = Path.GetRelativePath(targetDirectory, file);
 
 			if (string.IsNullOrEmpty(relativeFilePath)) {
-				ArchiLogger.LogNullError(nameof(relativeFilePath));
+				ArchiLogger.LogNullError(relativeFilePath);
 
 				return false;
 			}
@@ -990,7 +990,7 @@ public static class ASF {
 
 			switch (relativeDirectoryName) {
 				case null:
-					ArchiLogger.LogNullError(nameof(relativeDirectoryName));
+					ArchiLogger.LogNullError(relativeDirectoryName);
 
 					return false;
 				case "":
@@ -1054,7 +1054,7 @@ public static class ASF {
 				string? directory = Path.GetDirectoryName(file);
 
 				if (string.IsNullOrEmpty(directory)) {
-					ArchiLogger.LogNullError(nameof(directory));
+					ArchiLogger.LogNullError(directory);
 
 					return false;
 				}

--- a/ArchiSteamFarm/Core/RemoteCommunication.cs
+++ b/ArchiSteamFarm/Core/RemoteCommunication.cs
@@ -187,7 +187,7 @@ internal sealed class RemoteCommunication : IAsyncDisposable {
 			HashSet<Asset.EType> acceptedMatchableTypes = Bot.BotConfig.MatchableTypes.Where(AcceptedMatchableTypes.Contains).ToHashSet();
 
 			if (acceptedMatchableTypes.Count == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(acceptedMatchableTypes));
+				Bot.ArchiLogger.LogNullError(acceptedMatchableTypes);
 				LastAnnouncementCheck = DateTime.UtcNow;
 				ShouldSendHeartBeats = false;
 
@@ -480,7 +480,7 @@ internal sealed class RemoteCommunication : IAsyncDisposable {
 					if (inventoryStateChanges.TryGetValue(set, out Dictionary<ulong, uint>? pastChanges) && (pastChanges.Count > 0)) {
 						foreach ((ulong classID, uint amount) in pastChanges) {
 							if (!ourFullSet.TryGetValue(classID, out uint fullAmount) || (fullAmount == 0) || (fullAmount < amount)) {
-								Bot.ArchiLogger.LogNullError(nameof(fullAmount));
+								Bot.ArchiLogger.LogNullError(fullAmount);
 
 								return (false, skippedSetsThisRound.Count > 0);
 							}
@@ -492,7 +492,7 @@ internal sealed class RemoteCommunication : IAsyncDisposable {
 							}
 
 							if (!ourTradableSet.TryGetValue(classID, out uint tradableAmount) || (tradableAmount == 0) || (tradableAmount < amount)) {
-								Bot.ArchiLogger.LogNullError(nameof(tradableAmount));
+								Bot.ArchiLogger.LogNullError(tradableAmount);
 
 								return (false, skippedSetsThisRound.Count > 0);
 							}

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -305,7 +305,7 @@ public static class Utilities {
 		ResourceSet? defaultResourceSet = resourceManager.GetResourceSet(CultureInfo.GetCultureInfo("en-US"), true, true);
 
 		if (defaultResourceSet == null) {
-			ASF.ArchiLogger.LogNullError(nameof(defaultResourceSet));
+			ASF.ArchiLogger.LogNullError(defaultResourceSet);
 
 			return;
 		}
@@ -313,7 +313,7 @@ public static class Utilities {
 		HashSet<DictionaryEntry> defaultStringObjects = defaultResourceSet.Cast<DictionaryEntry>().ToHashSet();
 
 		if (defaultStringObjects.Count == 0) {
-			ASF.ArchiLogger.LogNullError(nameof(defaultStringObjects));
+			ASF.ArchiLogger.LogNullError(defaultStringObjects);
 
 			return;
 		}
@@ -322,7 +322,7 @@ public static class Utilities {
 		ResourceSet? currentResourceSet = resourceManager.GetResourceSet(CultureInfo.CurrentUICulture, true, true);
 
 		if (currentResourceSet == null) {
-			ASF.ArchiLogger.LogNullError(nameof(currentResourceSet));
+			ASF.ArchiLogger.LogNullError(currentResourceSet);
 
 			return;
 		}

--- a/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
+++ b/ArchiSteamFarm/Helpers/CrossProcessFileBasedSemaphore.cs
@@ -162,7 +162,7 @@ internal sealed class CrossProcessFileBasedSemaphore : ICrossProcessSemaphore, I
 		string? directoryPath = Path.GetDirectoryName(FilePath);
 
 		if (string.IsNullOrEmpty(directoryPath)) {
-			ASF.ArchiLogger.LogNullError(nameof(directoryPath));
+			ASF.ArchiLogger.LogNullError(directoryPath);
 
 			return;
 		}

--- a/ArchiSteamFarm/IPC/Controllers/Api/TypeController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/TypeController.cs
@@ -95,7 +95,7 @@ public sealed class TypeController : ArchiController {
 				string? valueText = value?.ToString();
 
 				if (string.IsNullOrEmpty(valueText)) {
-					ASF.ArchiLogger.LogNullError(nameof(valueText));
+					ASF.ArchiLogger.LogNullError(valueText);
 
 					return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorObjectIsNull, nameof(valueText))));
 				}

--- a/ArchiSteamFarm/NLog/ArchiLogger.cs
+++ b/ArchiSteamFarm/NLog/ArchiLogger.cs
@@ -115,7 +115,7 @@ public sealed class ArchiLogger {
 	}
 
 	[PublicAPI]
-	public void LogNullError(string nullObjectName, [CallerMemberName] string? previousMethodName = null) {
+	public void LogNullError(object? nullObject, [CallerArgumentExpression("nullObject")] string? nullObjectName = null, [CallerMemberName] string? previousMethodName = null) {
 		if (string.IsNullOrEmpty(nullObjectName)) {
 			throw new ArgumentNullException(nameof(nullObjectName));
 		}

--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -366,7 +366,7 @@ internal static class Logging {
 						string? response = await targetBot.Commands.Response(EAccess.Owner, command!).ConfigureAwait(false);
 
 						if (string.IsNullOrEmpty(response)) {
-							ASF.ArchiLogger.LogNullError(nameof(response));
+							ASF.ArchiLogger.LogNullError(response);
 							Console.WriteLine(Strings.ErrorIsEmpty, nameof(response));
 
 							continue;

--- a/ArchiSteamFarm/NLog/Targets/HistoryTarget.cs
+++ b/ArchiSteamFarm/NLog/Targets/HistoryTarget.cs
@@ -46,7 +46,7 @@ internal sealed class HistoryTarget : TargetWithLayout {
 
 		set {
 			if (value == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -2193,8 +2193,14 @@ public sealed class Bot : IAsyncDisposable {
 	}
 
 	private static async Task LimitLoginRequestsAsync() {
-		if ((ASF.LoginSemaphore == null) || (ASF.LoginRateLimitingSemaphore == null)) {
-			ASF.ArchiLogger.LogNullError(null, $"{nameof(ASF.LoginSemaphore)} || {nameof(ASF.LoginRateLimitingSemaphore)}");
+		if (ASF.LoginSemaphore == null) {
+			ASF.ArchiLogger.LogNullError(ASF.LoginSemaphore);
+
+			return;
+		}
+
+		if (ASF.LoginRateLimitingSemaphore == null) {
+			ASF.ArchiLogger.LogNullError(ASF.LoginRateLimitingSemaphore);
 
 			return;
 		}
@@ -2517,8 +2523,20 @@ public sealed class Bot : IAsyncDisposable {
 	private async Task OnIncomingChatMessage(CChatRoom_IncomingChatMessage_Notification notification) {
 		ArgumentNullException.ThrowIfNull(notification);
 
-		if ((notification.chat_group_id == 0) || (notification.chat_id == 0) || (notification.steamid_sender == 0)) {
-			ArchiLogger.LogNullError(null, $"{nameof(notification.chat_group_id)} || {nameof(notification.chat_id)} || {nameof(notification.steamid_sender)}");
+		if (notification.chat_group_id == 0) {
+			ArchiLogger.LogNullError(notification.chat_group_id);
+
+			return;
+		}
+
+		if (notification.chat_id == 0) {
+			ArchiLogger.LogNullError(notification.chat_id);
+
+			return;
+		}
+
+		if (notification.steamid_sender == 0) {
+			ArchiLogger.LogNullError(notification.steamid_sender);
 
 			return;
 		}
@@ -3153,8 +3171,14 @@ public sealed class Bot : IAsyncDisposable {
 			while (IsConnectedAndLoggedOn && BotDatabase.HasGamesToRedeemInBackground) {
 				(string? key, string? name) = BotDatabase.GetGameToRedeemInBackground();
 
-				if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(name)) {
-					ArchiLogger.LogNullError(null, $"{nameof(key)} || {nameof(name)}");
+				if (string.IsNullOrEmpty(key)) {
+					ArchiLogger.LogNullError(key);
+
+					break;
+				}
+
+				if (string.IsNullOrEmpty(name)) {
+					ArchiLogger.LogNullError(name);
 
 					break;
 				}

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -165,7 +165,7 @@ public sealed class Bot : IAsyncDisposable {
 				string filePath = GetFilePath(fileType);
 
 				if (string.IsNullOrEmpty(filePath)) {
-					ArchiLogger.LogNullError(nameof(filePath));
+					ArchiLogger.LogNullError(filePath);
 
 					yield break;
 				}
@@ -654,13 +654,13 @@ public sealed class Bot : IAsyncDisposable {
 			string lastPage = htmlNode.TextContent;
 
 			if (string.IsNullOrEmpty(lastPage)) {
-				ArchiLogger.LogNullError(nameof(lastPage));
+				ArchiLogger.LogNullError(lastPage);
 
 				return null;
 			}
 
 			if (!byte.TryParse(lastPage, out maxPages) || (maxPages == 0)) {
-				ArchiLogger.LogNullError(nameof(maxPages));
+				ArchiLogger.LogNullError(maxPages);
 
 				return null;
 			}
@@ -951,7 +951,7 @@ public sealed class Bot : IAsyncDisposable {
 		string unusedKeysFilePath = GetFilePath(EFileType.KeysToRedeemUnused);
 
 		if (string.IsNullOrEmpty(unusedKeysFilePath)) {
-			ASF.ArchiLogger.LogNullError(nameof(unusedKeysFilePath));
+			ASF.ArchiLogger.LogNullError(unusedKeysFilePath);
 
 			return false;
 		}
@@ -969,7 +969,7 @@ public sealed class Bot : IAsyncDisposable {
 		string usedKeysFilePath = GetFilePath(EFileType.KeysToRedeemUsed);
 
 		if (string.IsNullOrEmpty(usedKeysFilePath)) {
-			ASF.ArchiLogger.LogNullError(nameof(usedKeysFilePath));
+			ASF.ArchiLogger.LogNullError(usedKeysFilePath);
 
 			return false;
 		}
@@ -1074,7 +1074,7 @@ public sealed class Bot : IAsyncDisposable {
 			KeyValue productInfo = productInfoApp.KeyValues;
 
 			if (productInfo == KeyValue.Invalid) {
-				ArchiLogger.LogNullError(nameof(productInfo));
+				ArchiLogger.LogNullError(productInfo);
 
 				break;
 			}
@@ -1151,7 +1151,7 @@ public sealed class Bot : IAsyncDisposable {
 
 			foreach (string dlcAppIDsText in dlcAppIDsTexts) {
 				if (!uint.TryParse(dlcAppIDsText, out uint dlcAppID) || (dlcAppID == 0)) {
-					ArchiLogger.LogNullError(nameof(dlcAppID));
+					ArchiLogger.LogNullError(dlcAppID);
 
 					break;
 				}
@@ -1212,7 +1212,7 @@ public sealed class Bot : IAsyncDisposable {
 
 		foreach (SteamApps.PICSProductInfoCallback.PICSProductInfo productInfo in productInfoResultSet.Results.SelectMany(static productInfoResult => productInfoResult.Packages).Where(static productInfoPackages => productInfoPackages.Key != 0).Select(static productInfoPackages => productInfoPackages.Value)) {
 			if (productInfo.KeyValues == KeyValue.Invalid) {
-				ArchiLogger.LogNullError(nameof(productInfo));
+				ArchiLogger.LogNullError(productInfo);
 
 				return null;
 			}
@@ -1231,7 +1231,7 @@ public sealed class Bot : IAsyncDisposable {
 
 				foreach (string? appIDText in appIDsKv.Children.Select(static app => app.Value)) {
 					if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
-						ArchiLogger.LogNullError(nameof(appID));
+						ArchiLogger.LogNullError(appID);
 
 						return null;
 					}
@@ -1388,7 +1388,7 @@ public sealed class Bot : IAsyncDisposable {
 		string configFile = GetFilePath(EFileType.Config);
 
 		if (string.IsNullOrEmpty(configFile)) {
-			ArchiLogger.LogNullError(nameof(configFile));
+			ArchiLogger.LogNullError(configFile);
 
 			return;
 		}
@@ -1490,7 +1490,7 @@ public sealed class Bot : IAsyncDisposable {
 		string configFilePath = GetFilePath(botName, EFileType.Config);
 
 		if (string.IsNullOrEmpty(configFilePath)) {
-			ASF.ArchiLogger.LogNullError(nameof(configFilePath));
+			ASF.ArchiLogger.LogNullError(configFilePath);
 
 			return;
 		}
@@ -1519,7 +1519,7 @@ public sealed class Bot : IAsyncDisposable {
 		string databaseFilePath = GetFilePath(botName, EFileType.Database);
 
 		if (string.IsNullOrEmpty(databaseFilePath)) {
-			ASF.ArchiLogger.LogNullError(nameof(databaseFilePath));
+			ASF.ArchiLogger.LogNullError(databaseFilePath);
 
 			return;
 		}
@@ -1548,7 +1548,7 @@ public sealed class Bot : IAsyncDisposable {
 			bot = new Bot(botName, botConfig, botDatabase);
 
 			if (!Bots.TryAdd(botName, bot)) {
-				ASF.ArchiLogger.LogNullError(nameof(bot));
+				ASF.ArchiLogger.LogNullError(bot);
 
 				await bot.DisposeAsync().ConfigureAwait(false);
 
@@ -1612,7 +1612,7 @@ public sealed class Bot : IAsyncDisposable {
 			string newFilePath = GetFilePath(newBotName, fileType);
 
 			if (string.IsNullOrEmpty(newFilePath)) {
-				ArchiLogger.LogNullError(nameof(newFilePath));
+				ArchiLogger.LogNullError(newFilePath);
 
 				return false;
 			}
@@ -1675,7 +1675,7 @@ public sealed class Bot : IAsyncDisposable {
 			string mobileAuthenticatorFilePath = GetFilePath(EFileType.MobileAuthenticator);
 
 			if (string.IsNullOrEmpty(mobileAuthenticatorFilePath)) {
-				ArchiLogger.LogNullError(nameof(mobileAuthenticatorFilePath));
+				ArchiLogger.LogNullError(mobileAuthenticatorFilePath);
 
 				return;
 			}
@@ -1688,7 +1688,7 @@ public sealed class Bot : IAsyncDisposable {
 		string keysToRedeemFilePath = GetFilePath(EFileType.KeysToRedeem);
 
 		if (string.IsNullOrEmpty(keysToRedeemFilePath)) {
-			ArchiLogger.LogNullError(nameof(keysToRedeemFilePath));
+			ArchiLogger.LogNullError(keysToRedeemFilePath);
 
 			return;
 		}
@@ -1887,7 +1887,7 @@ public sealed class Bot : IAsyncDisposable {
 
 		foreach (string? badgeUri in linkElements.Select(static htmlNode => htmlNode.GetAttribute("href"))) {
 			if (string.IsNullOrEmpty(badgeUri)) {
-				ArchiLogger.LogNullError(nameof(badgeUri));
+				ArchiLogger.LogNullError(badgeUri);
 
 				return null;
 			}
@@ -1896,7 +1896,7 @@ public sealed class Bot : IAsyncDisposable {
 			string appIDText = badgeUri.Split('?', StringSplitOptions.RemoveEmptyEntries)[0].Split('/', StringSplitOptions.RemoveEmptyEntries)[^1];
 
 			if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
-				ArchiLogger.LogNullError(nameof(appID));
+				ArchiLogger.LogNullError(appID);
 
 				return null;
 			}
@@ -1980,7 +1980,7 @@ public sealed class Bot : IAsyncDisposable {
 			MobileAuthenticator? authenticator = JsonConvert.DeserializeObject<MobileAuthenticator>(json);
 
 			if (authenticator == null) {
-				ArchiLogger.LogNullError(nameof(authenticator));
+				ArchiLogger.LogNullError(authenticator);
 
 				return;
 			}
@@ -2194,7 +2194,7 @@ public sealed class Bot : IAsyncDisposable {
 
 	private static async Task LimitLoginRequestsAsync() {
 		if ((ASF.LoginSemaphore == null) || (ASF.LoginRateLimitingSemaphore == null)) {
-			ASF.ArchiLogger.LogNullError($"{nameof(ASF.LoginSemaphore)} || {nameof(ASF.LoginRateLimitingSemaphore)}");
+			ASF.ArchiLogger.LogNullError(null, $"{nameof(ASF.LoginSemaphore)} || {nameof(ASF.LoginRateLimitingSemaphore)}");
 
 			return;
 		}
@@ -2242,7 +2242,7 @@ public sealed class Bot : IAsyncDisposable {
 		string sentryFilePath = GetFilePath(EFileType.SentryFile);
 
 		if (string.IsNullOrEmpty(sentryFilePath)) {
-			ArchiLogger.LogNullError(nameof(sentryFilePath));
+			ArchiLogger.LogNullError(sentryFilePath);
 
 			return;
 		}
@@ -2518,7 +2518,7 @@ public sealed class Bot : IAsyncDisposable {
 		ArgumentNullException.ThrowIfNull(notification);
 
 		if ((notification.chat_group_id == 0) || (notification.chat_id == 0) || (notification.steamid_sender == 0)) {
-			ArchiLogger.LogNullError($"{nameof(notification.chat_group_id)} || {nameof(notification.chat_id)} || {nameof(notification.steamid_sender)}");
+			ArchiLogger.LogNullError(null, $"{nameof(notification.chat_group_id)} || {nameof(notification.chat_id)} || {nameof(notification.steamid_sender)}");
 
 			return;
 		}
@@ -2558,7 +2558,7 @@ public sealed class Bot : IAsyncDisposable {
 		ArgumentNullException.ThrowIfNull(notification);
 
 		if (notification.steamid_friend == 0) {
-			ArchiLogger.LogNullError(nameof(notification.steamid_friend));
+			ArchiLogger.LogNullError(notification.steamid_friend);
 
 			return;
 		}
@@ -2939,7 +2939,7 @@ public sealed class Bot : IAsyncDisposable {
 		string sentryFilePath = GetFilePath(EFileType.SentryFile);
 
 		if (string.IsNullOrEmpty(sentryFilePath)) {
-			ArchiLogger.LogNullError(nameof(sentryFilePath));
+			ArchiLogger.LogNullError(sentryFilePath);
 
 			return;
 		}
@@ -3154,7 +3154,7 @@ public sealed class Bot : IAsyncDisposable {
 				(string? key, string? name) = BotDatabase.GetGameToRedeemInBackground();
 
 				if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(name)) {
-					ArchiLogger.LogNullError($"{nameof(key)} || {nameof(name)}");
+					ArchiLogger.LogNullError(null, $"{nameof(key)} || {nameof(name)}");
 
 					break;
 				}
@@ -3229,7 +3229,7 @@ public sealed class Bot : IAsyncDisposable {
 				string filePath = GetFilePath(redeemed ? EFileType.KeysToRedeemUsed : EFileType.KeysToRedeemUnused);
 
 				if (string.IsNullOrEmpty(filePath)) {
-					ArchiLogger.LogNullError(nameof(filePath));
+					ArchiLogger.LogNullError(filePath);
 
 					return;
 				}

--- a/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
+++ b/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
@@ -327,7 +327,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			}
 
 			if (GamesToFarm.Count == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(GamesToFarm));
+				Bot.ArchiLogger.LogNullError(GamesToFarm);
 
 				return;
 			}
@@ -461,7 +461,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string? appIDText = appIDNode.GetAttribute("id");
 
 			if (string.IsNullOrEmpty(appIDText)) {
-				Bot.ArchiLogger.LogNullError(nameof(appIDText));
+				Bot.ArchiLogger.LogNullError(appIDText);
 
 				continue;
 			}
@@ -469,7 +469,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string[] appIDSplitted = appIDText.Split('_');
 
 			if (appIDSplitted.Length < 5) {
-				Bot.ArchiLogger.LogNullError(nameof(appIDSplitted));
+				Bot.ArchiLogger.LogNullError(appIDSplitted);
 
 				continue;
 			}
@@ -477,7 +477,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			appIDText = appIDSplitted[4];
 
 			if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(appID));
+				Bot.ArchiLogger.LogNullError(appID);
 
 				continue;
 			}
@@ -518,7 +518,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			IElement? progressNode = statsNode?.SelectSingleElementNode(".//span[@class='progress_info_bold']");
 
 			if (progressNode == null) {
-				Bot.ArchiLogger.LogNullError(nameof(progressNode));
+				Bot.ArchiLogger.LogNullError(progressNode);
 
 				continue;
 			}
@@ -526,7 +526,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string progressText = progressNode.TextContent;
 
 			if (string.IsNullOrEmpty(progressText)) {
-				Bot.ArchiLogger.LogNullError(nameof(progressText));
+				Bot.ArchiLogger.LogNullError(progressText);
 
 				continue;
 			}
@@ -537,7 +537,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			// This might fail if we have no card drops remaining, 0 is not printed in this case - that's fine
 			if (progressMatch.Success) {
 				if (!ushort.TryParse(progressMatch.Value, out cardsRemaining) || (cardsRemaining == 0)) {
-					Bot.ArchiLogger.LogNullError(nameof(cardsRemaining));
+					Bot.ArchiLogger.LogNullError(cardsRemaining);
 
 					continue;
 				}
@@ -557,7 +557,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				IElement? cardsEarnedNode = statsNode?.SelectSingleElementNode(".//div[@class='card_drop_info_header']");
 
 				if (cardsEarnedNode == null) {
-					Bot.ArchiLogger.LogNullError(nameof(cardsEarnedNode));
+					Bot.ArchiLogger.LogNullError(cardsEarnedNode);
 
 					continue;
 				}
@@ -565,7 +565,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				string cardsEarnedText = cardsEarnedNode.TextContent;
 
 				if (string.IsNullOrEmpty(cardsEarnedText)) {
-					Bot.ArchiLogger.LogNullError(nameof(cardsEarnedText));
+					Bot.ArchiLogger.LogNullError(cardsEarnedText);
 
 					continue;
 				}
@@ -573,13 +573,13 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				Match cardsEarnedMatch = Regex.Match(cardsEarnedText, @"\d+");
 
 				if (!cardsEarnedMatch.Success) {
-					Bot.ArchiLogger.LogNullError(nameof(cardsEarnedMatch));
+					Bot.ArchiLogger.LogNullError(cardsEarnedMatch);
 
 					continue;
 				}
 
 				if (!ushort.TryParse(cardsEarnedMatch.Value, out ushort cardsEarned)) {
-					Bot.ArchiLogger.LogNullError(nameof(cardsEarned));
+					Bot.ArchiLogger.LogNullError(cardsEarned);
 
 					continue;
 				}
@@ -602,7 +602,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			IElement? timeNode = statsNode?.SelectSingleElementNode(".//div[@class='badge_title_stats_playtime']");
 
 			if (timeNode == null) {
-				Bot.ArchiLogger.LogNullError(nameof(timeNode));
+				Bot.ArchiLogger.LogNullError(timeNode);
 
 				continue;
 			}
@@ -610,7 +610,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string hoursText = timeNode.TextContent;
 
 			if (string.IsNullOrEmpty(hoursText)) {
-				Bot.ArchiLogger.LogNullError(nameof(hoursText));
+				Bot.ArchiLogger.LogNullError(hoursText);
 
 				continue;
 			}
@@ -621,7 +621,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			// This might fail if we have exactly 0.0 hours played, as it's not printed in that case - that's fine
 			if (hoursMatch.Success) {
 				if (!float.TryParse(hoursMatch.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out hours) || (hours <= 0.0F)) {
-					Bot.ArchiLogger.LogNullError(nameof(hours));
+					Bot.ArchiLogger.LogNullError(hours);
 
 					continue;
 				}
@@ -631,7 +631,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			IElement? nameNode = statsNode?.SelectSingleElementNode("(.//div[@class='card_drop_info_body'])[last()]");
 
 			if (nameNode == null) {
-				Bot.ArchiLogger.LogNullError(nameof(nameNode));
+				Bot.ArchiLogger.LogNullError(nameNode);
 
 				continue;
 			}
@@ -639,7 +639,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string name = nameNode.TextContent;
 
 			if (string.IsNullOrEmpty(name)) {
-				Bot.ArchiLogger.LogNullError(nameof(name));
+				Bot.ArchiLogger.LogNullError(name);
 
 				continue;
 			}
@@ -651,7 +651,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				nameStartIndex = name.IndexOf("You don't have any more drops remaining for ", StringComparison.Ordinal);
 
 				if (nameStartIndex <= 0) {
-					Bot.ArchiLogger.LogNullError(nameof(nameStartIndex));
+					Bot.ArchiLogger.LogNullError(nameStartIndex);
 
 					continue;
 				}
@@ -664,7 +664,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			int nameEndIndex = name.LastIndexOf('.');
 
 			if (nameEndIndex <= nameStartIndex) {
-				Bot.ArchiLogger.LogNullError(nameof(nameEndIndex));
+				Bot.ArchiLogger.LogNullError(nameEndIndex);
 
 				continue;
 			}
@@ -672,7 +672,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			name = WebUtility.HtmlDecode(name[nameStartIndex..nameEndIndex]);
 
 			if (string.IsNullOrEmpty(name)) {
-				Bot.ArchiLogger.LogNullError(nameof(name));
+				Bot.ArchiLogger.LogNullError(name);
 
 				continue;
 			}
@@ -687,7 +687,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				string levelText = levelNode.TextContent;
 
 				if (string.IsNullOrEmpty(levelText)) {
-					Bot.ArchiLogger.LogNullError(nameof(levelText));
+					Bot.ArchiLogger.LogNullError(levelText);
 
 					continue;
 				}
@@ -695,7 +695,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				int levelStartIndex = levelText.IndexOf("Level ", StringComparison.OrdinalIgnoreCase);
 
 				if (levelStartIndex < 0) {
-					Bot.ArchiLogger.LogNullError(nameof(levelStartIndex));
+					Bot.ArchiLogger.LogNullError(levelStartIndex);
 
 					continue;
 				}
@@ -703,7 +703,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				levelStartIndex += 6;
 
 				if (levelText.Length <= levelStartIndex) {
-					Bot.ArchiLogger.LogNullError(nameof(levelStartIndex));
+					Bot.ArchiLogger.LogNullError(levelStartIndex);
 
 					continue;
 				}
@@ -711,7 +711,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				int levelEndIndex = levelText.IndexOf(',', levelStartIndex);
 
 				if (levelEndIndex <= levelStartIndex) {
-					Bot.ArchiLogger.LogNullError(nameof(levelEndIndex));
+					Bot.ArchiLogger.LogNullError(levelEndIndex);
 
 					continue;
 				}
@@ -719,7 +719,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 				levelText = levelText[levelStartIndex..levelEndIndex];
 
 				if (!byte.TryParse(levelText, out badgeLevel) || badgeLevel is 0 or > 5) {
-					Bot.ArchiLogger.LogNullError(nameof(badgeLevel));
+					Bot.ArchiLogger.LogNullError(badgeLevel);
 
 					continue;
 				}
@@ -911,7 +911,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 		float maxHour = games.Max(static game => game.HoursPlayed);
 
 		if (maxHour < 0) {
-			Bot.ArchiLogger.LogNullError(nameof(maxHour));
+			Bot.ArchiLogger.LogNullError(maxHour);
 
 			return false;
 		}
@@ -1011,7 +1011,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 		string progress = progressNode.TextContent;
 
 		if (string.IsNullOrEmpty(progress)) {
-			Bot.ArchiLogger.LogNullError(nameof(progress));
+			Bot.ArchiLogger.LogNullError(progress);
 
 			return null;
 		}
@@ -1023,7 +1023,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 		}
 
 		if (!ushort.TryParse(match.Value, out ushort cardsRemaining) || (cardsRemaining == 0)) {
-			Bot.ArchiLogger.LogNullError(nameof(cardsRemaining));
+			Bot.ArchiLogger.LogNullError(cardsRemaining);
 
 			return null;
 		}
@@ -1051,13 +1051,13 @@ public sealed class CardsFarmer : IAsyncDisposable {
 			string lastPage = htmlNode.TextContent;
 
 			if (string.IsNullOrEmpty(lastPage)) {
-				Bot.ArchiLogger.LogNullError(nameof(lastPage));
+				Bot.ArchiLogger.LogNullError(lastPage);
 
 				return null;
 			}
 
 			if (!byte.TryParse(lastPage, out maxPages) || (maxPages == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(maxPages));
+				Bot.ArchiLogger.LogNullError(maxPages);
 
 				return null;
 			}
@@ -1229,7 +1229,7 @@ public sealed class CardsFarmer : IAsyncDisposable {
 						if (packageIDs != null) {
 							foreach (uint packageID in packageIDs) {
 								if (!Bot.OwnedPackageIDs.TryGetValue(packageID, out (EPaymentMethod PaymentMethod, DateTime TimeCreated) packageData)) {
-									Bot.ArchiLogger.LogNullError(nameof(packageData));
+									Bot.ArchiLogger.LogNullError(packageData);
 
 									return;
 								}

--- a/ArchiSteamFarm/Steam/Data/Asset.cs
+++ b/ArchiSteamFarm/Steam/Data/Asset.cs
@@ -98,13 +98,13 @@ public sealed class Asset {
 
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
 
 			if (!uint.TryParse(value, out uint amount) || (amount == 0)) {
-				ASF.ArchiLogger.LogNullError(nameof(amount));
+				ASF.ArchiLogger.LogNullError(amount);
 
 				return;
 			}
@@ -119,13 +119,13 @@ public sealed class Asset {
 
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
 
 			if (!ulong.TryParse(value, out ulong assetID) || (assetID == 0)) {
-				ASF.ArchiLogger.LogNullError(nameof(assetID));
+				ASF.ArchiLogger.LogNullError(assetID);
 
 				return;
 			}
@@ -138,7 +138,7 @@ public sealed class Asset {
 	private string ClassIDText {
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
@@ -157,13 +157,13 @@ public sealed class Asset {
 
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
 
 			if (!ulong.TryParse(value, out ulong contextID) || (contextID == 0)) {
-				ASF.ArchiLogger.LogNullError(nameof(contextID));
+				ASF.ArchiLogger.LogNullError(contextID);
 
 				return;
 			}
@@ -185,7 +185,7 @@ public sealed class Asset {
 			}
 
 			if (!ulong.TryParse(value, out ulong instanceID)) {
-				ASF.ArchiLogger.LogNullError(nameof(instanceID));
+				ASF.ArchiLogger.LogNullError(instanceID);
 
 				return;
 			}

--- a/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
+++ b/ArchiSteamFarm/Steam/Data/InventoryResponse.cs
@@ -53,13 +53,13 @@ internal sealed class InventoryResponse : OptionalResultResponse {
 	private string LastAssetIDText {
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
 
 			if (!ulong.TryParse(value, out ulong lastAssetID) || (lastAssetID == 0)) {
-				ASF.ArchiLogger.LogNullError(nameof(lastAssetID));
+				ASF.ArchiLogger.LogNullError(lastAssetID);
 
 				return;
 			}
@@ -117,7 +117,7 @@ internal sealed class InventoryResponse : OptionalResultResponse {
 							string appIDText = tag.Value[4..];
 
 							if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
-								ASF.ArchiLogger.LogNullError(nameof(appID));
+								ASF.ArchiLogger.LogNullError(appID);
 
 								break;
 							}
@@ -217,13 +217,13 @@ internal sealed class InventoryResponse : OptionalResultResponse {
 		private string ClassIDText {
 			set {
 				if (string.IsNullOrEmpty(value)) {
-					ASF.ArchiLogger.LogNullError(nameof(value));
+					ASF.ArchiLogger.LogNullError(value);
 
 					return;
 				}
 
 				if (!ulong.TryParse(value, out ulong classID) || (classID == 0)) {
-					ASF.ArchiLogger.LogNullError(nameof(classID));
+					ASF.ArchiLogger.LogNullError(classID);
 
 					return;
 				}
@@ -240,7 +240,7 @@ internal sealed class InventoryResponse : OptionalResultResponse {
 				}
 
 				if (!ulong.TryParse(value, out ulong instanceID)) {
-					ASF.ArchiLogger.LogNullError(nameof(instanceID));
+					ASF.ArchiLogger.LogNullError(instanceID);
 
 					return;
 				}

--- a/ArchiSteamFarm/Steam/Data/TradeOfferSendResponse.cs
+++ b/ArchiSteamFarm/Steam/Data/TradeOfferSendResponse.cs
@@ -39,13 +39,13 @@ internal sealed class TradeOfferSendResponse {
 	private string TradeOfferIDText {
 		set {
 			if (string.IsNullOrEmpty(value)) {
-				ASF.ArchiLogger.LogNullError(nameof(value));
+				ASF.ArchiLogger.LogNullError(value);
 
 				return;
 			}
 
 			if (!ulong.TryParse(value, out ulong tradeOfferID) || (tradeOfferID == 0)) {
-				ASF.ArchiLogger.LogNullError(nameof(tradeOfferID));
+				ASF.ArchiLogger.LogNullError(tradeOfferID);
 
 				return;
 			}

--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -322,7 +322,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		KeyValue pointsInfo = response["summary"]["points"];
 
 		if (pointsInfo == KeyValue.Invalid) {
-			Bot.ArchiLogger.LogNullError(nameof(pointsInfo));
+			Bot.ArchiLogger.LogNullError(pointsInfo);
 
 			return null;
 		}
@@ -330,7 +330,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		uint result = pointsInfo.AsUnsignedInteger(uint.MaxValue);
 
 		if (result == uint.MaxValue) {
-			Bot.ArchiLogger.LogNullError(nameof(result));
+			Bot.ArchiLogger.LogNullError(result);
 
 			return null;
 		}
@@ -451,7 +451,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			}
 
 			if (response.Content.TradeOfferID == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(response.Content.TradeOfferID));
+				Bot.ArchiLogger.LogNullError(response.Content.TradeOfferID);
 
 				return (false, mobileTradeOfferIDs);
 			}
@@ -785,7 +785,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			string? sessionID = WebBrowser.CookieContainer.GetCookieValue(host, "sessionid");
 
 			if (string.IsNullOrEmpty(sessionID)) {
-				Bot.ArchiLogger.LogNullError(nameof(sessionID));
+				Bot.ArchiLogger.LogNullError(sessionID);
 
 				return null;
 			}
@@ -899,7 +899,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			string? sessionID = WebBrowser.CookieContainer.GetCookieValue(host, "sessionid");
 
 			if (string.IsNullOrEmpty(sessionID)) {
-				Bot.ArchiLogger.LogNullError(nameof(sessionID));
+				Bot.ArchiLogger.LogNullError(sessionID);
 
 				return null;
 			}
@@ -1013,7 +1013,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			string? sessionID = WebBrowser.CookieContainer.GetCookieValue(host, "sessionid");
 
 			if (string.IsNullOrEmpty(sessionID)) {
-				Bot.ArchiLogger.LogNullError(nameof(sessionID));
+				Bot.ArchiLogger.LogNullError(sessionID);
 
 				return null;
 			}
@@ -1129,7 +1129,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			string? sessionID = WebBrowser.CookieContainer.GetCookieValue(host, "sessionid");
 
 			if (string.IsNullOrEmpty(sessionID)) {
-				Bot.ArchiLogger.LogNullError(nameof(sessionID));
+				Bot.ArchiLogger.LogNullError(sessionID);
 
 				return false;
 			}
@@ -1510,7 +1510,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			uint appID = description["appid"].AsUnsignedInteger();
 
 			if (appID == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(appID));
+				Bot.ArchiLogger.LogNullError(appID);
 
 				return null;
 			}
@@ -1518,7 +1518,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			ulong classID = description["classid"].AsUnsignedLong();
 
 			if (classID == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(classID));
+				Bot.ArchiLogger.LogNullError(classID);
 
 				return null;
 			}
@@ -1548,7 +1548,7 @@ public sealed class ArchiWebHandler : IDisposable {
 					string? identifier = tag["category"].AsString();
 
 					if (string.IsNullOrEmpty(identifier)) {
-						Bot.ArchiLogger.LogNullError(nameof(identifier));
+						Bot.ArchiLogger.LogNullError(identifier);
 
 						return null;
 					}
@@ -1557,7 +1557,7 @@ public sealed class ArchiWebHandler : IDisposable {
 
 					// Apparently, name can be empty, but not null
 					if (value == null) {
-						Bot.ArchiLogger.LogNullError(nameof(value));
+						Bot.ArchiLogger.LogNullError(value);
 
 						return null;
 					}
@@ -1578,7 +1578,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			ETradeOfferState state = trade["trade_offer_state"].AsEnum<ETradeOfferState>();
 
 			if (!Enum.IsDefined(state)) {
-				Bot.ArchiLogger.LogNullError(nameof(state));
+				Bot.ArchiLogger.LogNullError(state);
 
 				return null;
 			}
@@ -1590,7 +1590,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			ulong tradeOfferID = trade["tradeofferid"].AsUnsignedLong();
 
 			if (tradeOfferID == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(tradeOfferID));
+				Bot.ArchiLogger.LogNullError(tradeOfferID);
 
 				return null;
 			}
@@ -1598,7 +1598,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			uint otherSteamID3 = trade["accountid_other"].AsUnsignedInteger();
 
 			if (otherSteamID3 == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(otherSteamID3));
+				Bot.ArchiLogger.LogNullError(otherSteamID3);
 
 				return null;
 			}
@@ -1675,7 +1675,7 @@ public sealed class ArchiWebHandler : IDisposable {
 
 		foreach (uint appID in apps.Select(static app => app["appid"].AsUnsignedInteger())) {
 			if (appID == 0) {
-				Bot.ArchiLogger.LogNullError(nameof(appID));
+				Bot.ArchiLogger.LogNullError(appID);
 
 				return null;
 			}
@@ -1710,7 +1710,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		using IDocument? htmlDocument = await GetGameCardsPage(appID).ConfigureAwait(false);
 
 		if (htmlDocument == null) {
-			Bot.ArchiLogger.LogNullError(nameof(htmlDocument));
+			Bot.ArchiLogger.LogNullError(htmlDocument);
 
 			return 0;
 		}
@@ -1720,7 +1720,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		result = (byte) htmlNodes.Count();
 
 		if (result == 0) {
-			Bot.ArchiLogger.LogNullError(nameof(result));
+			Bot.ArchiLogger.LogNullError(result);
 
 			return 0;
 		}
@@ -1779,7 +1779,7 @@ public sealed class ArchiWebHandler : IDisposable {
 
 		foreach (string? giftCardIDText in htmlNodes.Select(static node => node.GetAttribute("id"))) {
 			if (string.IsNullOrEmpty(giftCardIDText)) {
-				Bot.ArchiLogger.LogNullError(nameof(giftCardIDText));
+				Bot.ArchiLogger.LogNullError(giftCardIDText);
 
 				return null;
 			}
@@ -1825,13 +1825,13 @@ public sealed class ArchiWebHandler : IDisposable {
 
 		foreach (string? miniProfile in htmlNodes.Select(static htmlNode => htmlNode.GetAttribute("data-miniprofile"))) {
 			if (string.IsNullOrEmpty(miniProfile)) {
-				Bot.ArchiLogger.LogNullError(nameof(miniProfile));
+				Bot.ArchiLogger.LogNullError(miniProfile);
 
 				return null;
 			}
 
 			if (!uint.TryParse(miniProfile, out uint steamID3) || (steamID3 == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(steamID3));
+				Bot.ArchiLogger.LogNullError(steamID3);
 
 				return null;
 			}
@@ -1890,7 +1890,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		uint result = response["server_time"].AsUnsignedInteger();
 
 		if (result == 0) {
-			Bot.ArchiLogger.LogNullError(nameof(result));
+			Bot.ArchiLogger.LogNullError(result);
 
 			return 0;
 		}
@@ -1917,7 +1917,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string text = htmlNode.TextContent;
 
 		if (string.IsNullOrEmpty(text)) {
-			Bot.ArchiLogger.LogNullError(nameof(text));
+			Bot.ArchiLogger.LogNullError(text);
 
 			return null;
 		}
@@ -1926,7 +1926,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		int index = text.IndexOf(daysTheirVariableName, StringComparison.Ordinal);
 
 		if (index < 0) {
-			Bot.ArchiLogger.LogNullError(nameof(index));
+			Bot.ArchiLogger.LogNullError(index);
 
 			return null;
 		}
@@ -1937,7 +1937,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		index = text.IndexOf(';', StringComparison.Ordinal);
 
 		if (index < 0) {
-			Bot.ArchiLogger.LogNullError(nameof(index));
+			Bot.ArchiLogger.LogNullError(index);
 
 			return null;
 		}
@@ -1945,7 +1945,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		text = text[..index];
 
 		if (!byte.TryParse(text, out byte result)) {
-			Bot.ArchiLogger.LogNullError(nameof(result));
+			Bot.ArchiLogger.LogNullError(result);
 
 			return null;
 		}
@@ -2010,7 +2010,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		uint resultInSeconds = response["their_escrow"]["escrow_end_duration_seconds"].AsUnsignedInteger(uint.MaxValue);
 
 		if (resultInSeconds == uint.MaxValue) {
-			Bot.ArchiLogger.LogNullError(nameof(resultInSeconds));
+			Bot.ArchiLogger.LogNullError(resultInSeconds);
 
 			return null;
 		}
@@ -2130,7 +2130,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		byte[]? publicKey = KeyDictionary.GetPublicKey(universe);
 
 		if ((publicKey == null) || (publicKey.Length == 0)) {
-			Bot.ArchiLogger.LogNullError(nameof(publicKey));
+			Bot.ArchiLogger.LogNullError(publicKey);
 
 			return false;
 		}
@@ -2189,7 +2189,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string? steamLogin = response["token"].AsString();
 
 		if (string.IsNullOrEmpty(steamLogin)) {
-			Bot.ArchiLogger.LogNullError(nameof(steamLogin));
+			Bot.ArchiLogger.LogNullError(steamLogin);
 
 			return false;
 		}
@@ -2197,7 +2197,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string? steamLoginSecure = response["tokensecure"].AsString();
 
 		if (string.IsNullOrEmpty(steamLoginSecure)) {
-			Bot.ArchiLogger.LogNullError(nameof(steamLoginSecure));
+			Bot.ArchiLogger.LogNullError(steamLoginSecure);
 
 			return false;
 		}
@@ -2300,7 +2300,7 @@ public sealed class ArchiWebHandler : IDisposable {
 
 		// ASF should redeem wallet key only in case of existing wallet
 		if (Bot.WalletCurrency == ECurrencyCode.Invalid) {
-			Bot.ArchiLogger.LogNullError(nameof(Bot.WalletCurrency));
+			Bot.ArchiLogger.LogNullError(Bot.WalletCurrency);
 
 			return null;
 		}
@@ -2366,7 +2366,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		IElement? titleNode = response.Content.SelectSingleNode("//div[@id='mainContents']/h2");
 
 		if (titleNode == null) {
-			Bot.ArchiLogger.LogNullError(nameof(titleNode));
+			Bot.ArchiLogger.LogNullError(titleNode);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2374,7 +2374,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string title = titleNode.TextContent;
 
 		if (string.IsNullOrEmpty(title)) {
-			Bot.ArchiLogger.LogNullError(nameof(title));
+			Bot.ArchiLogger.LogNullError(title);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2386,7 +2386,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		IElement? htmlNode = response.Content.SelectSingleNode("//div[@id='bodyContents_ex']/p");
 
 		if (htmlNode == null) {
-			Bot.ArchiLogger.LogNullError(nameof(htmlNode));
+			Bot.ArchiLogger.LogNullError(htmlNode);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2394,7 +2394,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string text = htmlNode.TextContent;
 
 		if (string.IsNullOrEmpty(text)) {
-			Bot.ArchiLogger.LogNullError(nameof(text));
+			Bot.ArchiLogger.LogNullError(text);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2406,7 +2406,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		int keyIndex = text.IndexOf("Key: ", StringComparison.Ordinal);
 
 		if (keyIndex < 0) {
-			Bot.ArchiLogger.LogNullError(nameof(keyIndex));
+			Bot.ArchiLogger.LogNullError(keyIndex);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2414,7 +2414,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		keyIndex += 5;
 
 		if (text.Length <= keyIndex) {
-			Bot.ArchiLogger.LogNullError(nameof(text));
+			Bot.ArchiLogger.LogNullError(text);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2422,7 +2422,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		text = text[keyIndex..];
 
 		if ((text.Length != 32) || !Utilities.IsValidHexadecimalText(text)) {
-			Bot.ArchiLogger.LogNullError(nameof(text));
+			Bot.ArchiLogger.LogNullError(text);
 
 			return (ESteamApiKeyState.Error, null);
 		}
@@ -2513,7 +2513,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			uint appID = item["appid"].AsUnsignedInteger();
 
 			if (appID == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(appID));
+				ASF.ArchiLogger.LogNullError(appID);
 
 				return false;
 			}
@@ -2521,7 +2521,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			ulong contextID = item["contextid"].AsUnsignedLong();
 
 			if (contextID == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(contextID));
+				ASF.ArchiLogger.LogNullError(contextID);
 
 				return false;
 			}
@@ -2529,7 +2529,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			ulong classID = item["classid"].AsUnsignedLong();
 
 			if (classID == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(classID));
+				ASF.ArchiLogger.LogNullError(classID);
 
 				return false;
 			}
@@ -2541,7 +2541,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			uint amount = item["amount"].AsUnsignedInteger();
 
 			if (amount == 0) {
-				ASF.ArchiLogger.LogNullError(nameof(amount));
+				ASF.ArchiLogger.LogNullError(amount);
 
 				return false;
 			}
@@ -2727,7 +2727,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		string? sessionID = WebBrowser.CookieContainer.GetCookieValue(service, "sessionid");
 
 		if (string.IsNullOrEmpty(sessionID)) {
-			Bot.ArchiLogger.LogNullError(nameof(sessionID));
+			Bot.ArchiLogger.LogNullError(sessionID);
 
 			return false;
 		}

--- a/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamSaleEvent.cs
@@ -104,7 +104,7 @@ internal sealed class SteamSaleEvent : IAsyncDisposable {
 		string text = htmlNode.TextContent;
 
 		if (string.IsNullOrEmpty(text)) {
-			Bot.ArchiLogger.LogNullError(nameof(text));
+			Bot.ArchiLogger.LogNullError(text);
 
 			return null;
 		}

--- a/ArchiSteamFarm/Steam/Integration/SteamUtilities.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamUtilities.cs
@@ -48,7 +48,7 @@ internal static class SteamUtilities {
 				packageID = lineItem["ItemAppID"].AsUnsignedInteger();
 
 				if (packageID == 0) {
-					ASF.ArchiLogger.LogNullError(nameof(packageID));
+					ASF.ArchiLogger.LogNullError(packageID);
 
 					return null;
 				}
@@ -57,7 +57,7 @@ internal static class SteamUtilities {
 			string? gameName = lineItem["ItemDescription"].AsString();
 
 			if (string.IsNullOrEmpty(gameName)) {
-				ASF.ArchiLogger.LogNullError(nameof(gameName));
+				ASF.ArchiLogger.LogNullError(gameName);
 
 				return null;
 			}

--- a/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
@@ -105,7 +105,7 @@ public sealed class MobileAuthenticator : IDisposable {
 		string? confirmationHash = GenerateConfirmationHash(time, "conf");
 
 		if (string.IsNullOrEmpty(confirmationHash)) {
-			Bot.ArchiLogger.LogNullError(nameof(confirmationHash));
+			Bot.ArchiLogger.LogNullError(confirmationHash);
 
 			return null;
 		}
@@ -129,13 +129,13 @@ public sealed class MobileAuthenticator : IDisposable {
 			string? idText = confirmationNode.GetAttribute("data-confid");
 
 			if (string.IsNullOrEmpty(idText)) {
-				Bot.ArchiLogger.LogNullError(nameof(idText));
+				Bot.ArchiLogger.LogNullError(idText);
 
 				return null;
 			}
 
 			if (!ulong.TryParse(idText, out ulong id) || (id == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(id));
+				Bot.ArchiLogger.LogNullError(id);
 
 				return null;
 			}
@@ -143,13 +143,13 @@ public sealed class MobileAuthenticator : IDisposable {
 			string? keyText = confirmationNode.GetAttribute("data-key");
 
 			if (string.IsNullOrEmpty(keyText)) {
-				Bot.ArchiLogger.LogNullError(nameof(keyText));
+				Bot.ArchiLogger.LogNullError(keyText);
 
 				return null;
 			}
 
 			if (!ulong.TryParse(keyText, out ulong key) || (key == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(key));
+				Bot.ArchiLogger.LogNullError(key);
 
 				return null;
 			}
@@ -157,13 +157,13 @@ public sealed class MobileAuthenticator : IDisposable {
 			string? creatorText = confirmationNode.GetAttribute("data-creator");
 
 			if (string.IsNullOrEmpty(creatorText)) {
-				Bot.ArchiLogger.LogNullError(nameof(creatorText));
+				Bot.ArchiLogger.LogNullError(creatorText);
 
 				return null;
 			}
 
 			if (!ulong.TryParse(creatorText, out ulong creator) || (creator == 0)) {
-				Bot.ArchiLogger.LogNullError(nameof(creator));
+				Bot.ArchiLogger.LogNullError(creator);
 
 				return null;
 			}
@@ -171,13 +171,13 @@ public sealed class MobileAuthenticator : IDisposable {
 			string? typeText = confirmationNode.GetAttribute("data-type");
 
 			if (string.IsNullOrEmpty(typeText)) {
-				Bot.ArchiLogger.LogNullError(nameof(typeText));
+				Bot.ArchiLogger.LogNullError(typeText);
 
 				return null;
 			}
 
 			if (!Enum.TryParse(typeText, out Confirmation.EType type) || (type == Confirmation.EType.Unknown)) {
-				Bot.ArchiLogger.LogNullError(nameof(type));
+				Bot.ArchiLogger.LogNullError(type);
 
 				return null;
 			}
@@ -220,7 +220,7 @@ public sealed class MobileAuthenticator : IDisposable {
 		string? confirmationHash = GenerateConfirmationHash(time, "conf");
 
 		if (string.IsNullOrEmpty(confirmationHash)) {
-			Bot.ArchiLogger.LogNullError(nameof(confirmationHash));
+			Bot.ArchiLogger.LogNullError(confirmationHash);
 
 			return false;
 		}

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -568,7 +568,7 @@ public sealed class BotConfig {
 		}
 
 		if (botConfig == null) {
-			ASF.ArchiLogger.LogNullError(nameof(botConfig));
+			ASF.ArchiLogger.LogNullError(botConfig);
 
 			return (null, null);
 		}

--- a/ArchiSteamFarm/Steam/Storage/BotDatabase.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotDatabase.cs
@@ -194,7 +194,7 @@ internal sealed class BotDatabase : SerializableFile {
 		}
 
 		if (botDatabase == null) {
-			ASF.ArchiLogger.LogNullError(nameof(botDatabase));
+			ASF.ArchiLogger.LogNullError(botDatabase);
 
 			return null;
 		}

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -488,7 +488,7 @@ public sealed class GlobalConfig {
 		}
 
 		if (globalConfig == null) {
-			ASF.ArchiLogger.LogNullError(nameof(globalConfig));
+			ASF.ArchiLogger.LogNullError(globalConfig);
 
 			return (null, null);
 		}

--- a/ArchiSteamFarm/Storage/GlobalDatabase.cs
+++ b/ArchiSteamFarm/Storage/GlobalDatabase.cs
@@ -227,7 +227,7 @@ public sealed class GlobalDatabase : SerializableFile {
 		}
 
 		if (globalDatabase == null) {
-			ASF.ArchiLogger.LogNullError(nameof(globalDatabase));
+			ASF.ArchiLogger.LogNullError(globalDatabase);
 
 			return null;
 		}

--- a/ArchiSteamFarm/Web/GitHub.cs
+++ b/ArchiSteamFarm/Web/GitHub.cs
@@ -94,7 +94,7 @@ internal static class GitHub {
 			IElement? versionNode = revisionNode.SelectSingleElementNode(".//input/@value");
 
 			if (versionNode == null) {
-				ASF.ArchiLogger.LogNullError(nameof(versionNode));
+				ASF.ArchiLogger.LogNullError(versionNode);
 
 				return null;
 			}
@@ -102,7 +102,7 @@ internal static class GitHub {
 			string versionText = versionNode.GetAttribute("value");
 
 			if (string.IsNullOrEmpty(versionText)) {
-				ASF.ArchiLogger.LogNullError(nameof(versionText));
+				ASF.ArchiLogger.LogNullError(versionText);
 
 				return null;
 			}
@@ -110,7 +110,7 @@ internal static class GitHub {
 			IElement? dateTimeNode = revisionNode.SelectSingleElementNode(".//relative-time/@datetime");
 
 			if (dateTimeNode == null) {
-				ASF.ArchiLogger.LogNullError(nameof(dateTimeNode));
+				ASF.ArchiLogger.LogNullError(dateTimeNode);
 
 				return null;
 			}
@@ -118,13 +118,13 @@ internal static class GitHub {
 			string dateTimeText = dateTimeNode.GetAttribute("datetime");
 
 			if (string.IsNullOrEmpty(dateTimeText)) {
-				ASF.ArchiLogger.LogNullError(nameof(dateTimeText));
+				ASF.ArchiLogger.LogNullError(dateTimeText);
 
 				return null;
 			}
 
 			if (!DateTime.TryParse(dateTimeText, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out DateTime dateTime)) {
-				ASF.ArchiLogger.LogNullError(nameof(dateTime));
+				ASF.ArchiLogger.LogNullError(dateTime);
 
 				return null;
 			}
@@ -223,7 +223,7 @@ internal static class GitHub {
 				}
 
 				if (Changelog == null) {
-					ASF.ArchiLogger.LogNullError(nameof(Changelog));
+					ASF.ArchiLogger.LogNullError(Changelog);
 
 					return null;
 				}
@@ -246,7 +246,7 @@ internal static class GitHub {
 				}
 
 				if (Changelog == null) {
-					ASF.ArchiLogger.LogNullError(nameof(Changelog));
+					ASF.ArchiLogger.LogNullError(Changelog);
 
 					return null;
 				}
@@ -276,7 +276,7 @@ internal static class GitHub {
 				}
 
 				if (string.IsNullOrEmpty(MarkdownBody)) {
-					ASF.ArchiLogger.LogNullError(nameof(MarkdownBody));
+					ASF.ArchiLogger.LogNullError(MarkdownBody);
 
 					return null;
 				}

--- a/ArchiSteamFarm/Web/WebBrowser.cs
+++ b/ArchiSteamFarm/Web/WebBrowser.cs
@@ -809,7 +809,7 @@ public sealed class WebBrowser : IDisposable {
 				Uri? redirectUri = response.Headers.Location;
 
 				if (redirectUri == null) {
-					ArchiLogger.LogNullError(nameof(redirectUri));
+					ArchiLogger.LogNullError(redirectUri);
 
 					return null;
 				}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageVersion Include="JustArchiNET.Madness" Version="3.4.0" />
+		<PackageVersion Include="JustArchiNET.Madness" Version="3.5.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-		<PackageVersion Include="JustArchiNET.Madness" Version="3.5.0" />
+		<PackageVersion Include="JustArchiNET.Madness" Version="3.5.1" />
 		<PackageVersion Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
 		<PackageVersion Include="Microsoft.AspNetCore.HttpOverrides" Version="2.2.0" />


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes


### Changed functionality

Following API changed in `ArchiLogger`:

```diff
- public void LogNullError(string nullObjectName, [CallerMemberName] string? previousMethodName = null);
+ public void LogNullError(object? nullObject, [CallerArgumentExpression("nullObject")] string? nullObjectName = null, [CallerMemberName] string? previousMethodName = null);
```

This enables us to change all calls to the method the following way (resulting in exactly the same log being written at runtime):

```diff
- ArchiLogger.LogNullError(nameof(globalCache));
+ ArchiLogger.LogNullError(globalCache);
```

Since the inlining of the expression string is done by the compiler, this also works for `net48`-builds.

Sadly this is a `PublicAPI` and I did not find a nice way of deprecating it gracefully. I would love your input on this issue.

## Additional info

Thank you in advance for considering the inclusion of this merge request.
