### PR TITLE
Rewrite Steam time to ulongs

### DIFF
--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -94,7 +94,7 @@ public static class Utilities {
 	}
 
 	[PublicAPI]
-	public static uint GetUnixTime() => (uint) DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+	public static ulong GetUnixTime() => (ulong) DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
 	[PublicAPI]
 	public static async void InBackground(Action action, bool longRunning = false) {
@@ -251,6 +251,16 @@ public static class Utilities {
 		} catch (Exception e) {
 			ASF.ArchiLogger.LogGenericException(e);
 		}
+	}
+
+	internal static ulong MathAdd(ulong first, int second) {
+		if (second >= 0) {
+			first += (uint) second;
+		} else {
+			first -= (uint) -second;
+		}
+
+		return first;
 	}
 
 	internal static bool RelativeDirectoryStartsWith(string directory, params string[] prefixes) {

--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -1678,7 +1678,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		return result;
 	}
 
-	internal async Task<IDocument?> GetConfirmationsPage(string deviceID, string confirmationHash, uint time) {
+	internal async Task<IDocument?> GetConfirmationsPage(string deviceID, string confirmationHash, ulong time) {
 		if (string.IsNullOrEmpty(deviceID)) {
 			throw new ArgumentNullException(nameof(deviceID));
 		}
@@ -1803,7 +1803,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		return response?.Content;
 	}
 
-	internal async Task<uint> GetServerTime() {
+	internal async Task<ulong> GetServerTime() {
 		KeyValue? response = null;
 
 		for (byte i = 0; (i < WebBrowser.MaxTries) && (response == null); i++) {
@@ -1835,7 +1835,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			return 0;
 		}
 
-		uint result = response["server_time"].AsUnsignedInteger();
+		ulong result = response["server_time"].AsUnsignedLong();
 
 		if (result == 0) {
 			Bot.ArchiLogger.LogNullError(result);
@@ -1966,7 +1966,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		return resultInSeconds == 0 ? (byte) 0 : (byte) (resultInSeconds / 86400);
 	}
 
-	internal async Task<bool?> HandleConfirmation(string deviceID, string confirmationHash, uint time, ulong confirmationID, ulong confirmationKey, bool accept) {
+	internal async Task<bool?> HandleConfirmation(string deviceID, string confirmationHash, ulong time, ulong confirmationID, ulong confirmationKey, bool accept) {
 		if (string.IsNullOrEmpty(deviceID)) {
 			throw new ArgumentNullException(nameof(deviceID));
 		}
@@ -2008,7 +2008,7 @@ public sealed class ArchiWebHandler : IDisposable {
 		return response?.Content.Success;
 	}
 
-	internal async Task<bool?> HandleConfirmations(string deviceID, string confirmationHash, uint time, IReadOnlyCollection<Confirmation> confirmations, bool accept) {
+	internal async Task<bool?> HandleConfirmations(string deviceID, string confirmationHash, ulong time, IReadOnlyCollection<Confirmation> confirmations, bool accept) {
 		if (string.IsNullOrEmpty(deviceID)) {
 			throw new ArgumentNullException(nameof(deviceID));
 		}


### PR DESCRIPTION
My latest "research" resulted in learning that under the hood, Steam unix time seconds is bullet-proof not only for year 2038 but for uint range as well. While I do not expect to be alive by 2106, let alone ASF still being operative, it makes sense to base our time on the correct backend implementation regardless.

Small breaking change for people using `GetUnixTime()`. Postponing until next release cycle.