### PR TITLE
Add endpoints to manage IPC bans

### DIFF
--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -122,7 +122,7 @@ internal static class ArchiKestrel {
 					webBuilder.UseKestrel(static (builderContext, options) => options.Configure(builderContext.Configuration.GetSection("Kestrel")));
 				} else {
 					// Use ASF defaults for Kestrel
-					webBuilder.UseKestrel(static options => options.ListenAnyIP(1242));
+					webBuilder.UseKestrel(static options => options.ListenLocalhost(1242));
 				}
 
 				// Specify Startup class for IPC

--- a/ArchiSteamFarm/IPC/ArchiKestrel.cs
+++ b/ArchiSteamFarm/IPC/ArchiKestrel.cs
@@ -122,7 +122,7 @@ internal static class ArchiKestrel {
 					webBuilder.UseKestrel(static (builderContext, options) => options.Configure(builderContext.Configuration.GetSection("Kestrel")));
 				} else {
 					// Use ASF defaults for Kestrel
-					webBuilder.UseKestrel(static options => options.ListenLocalhost(1242));
+					webBuilder.UseKestrel(static options => options.ListenAnyIP(1242));
 				}
 
 				// Specify Startup class for IPC

--- a/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
@@ -1,0 +1,78 @@
+﻿//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// |
+// Copyright 2015-2022 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using ArchiSteamFarm.IPC.Integration;
+using ArchiSteamFarm.IPC.Responses;
+using ArchiSteamFarm.Localization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ArchiSteamFarm.IPC.Controllers.Api;
+
+[Route("Api/IPC")]
+public sealed class IPCController : ArchiController {
+	/// <summary>
+	///     Clears the list of all IP addresses currently blocked by ASFs IPC module - Possible side effects include the removal of VAC bans
+	/// </summary>
+	[HttpDelete("Bans")]
+	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	public ActionResult<GenericResponse> BansDelete() {
+		ApiAuthenticationMiddleware.ClearFailedAuthorizations();
+
+		return Ok(new GenericResponse(true));
+	}
+
+	/// <summary>
+	///     Removes an IP address from the list of addresses currently blocked by ASFs IPC module
+	/// </summary>
+	[HttpDelete("Bans/{ipAddress:required}")]
+	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	public async Task<ActionResult<GenericResponse>> BansDeleteSpecific(string ipAddress) {
+		if (string.IsNullOrEmpty(ipAddress)) {
+			throw new ArgumentNullException(nameof(ipAddress));
+		}
+
+		if (!IPAddress.TryParse(ipAddress, out IPAddress? remoteAddress)) {
+			return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorIsInvalid, nameof(ipAddress))));
+		}
+
+		bool result = await ApiAuthenticationMiddleware.UnbanIP(remoteAddress).ConfigureAwait(false);
+
+		if (!result) {
+			return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorIPNotBanned, ipAddress)));
+		}
+
+		return Ok(new GenericResponse(true));
+	}
+
+	/// <summary>
+	///     Gets all IP addresses currently blocked by ASFs IPC module
+	/// </summary>
+	[HttpGet("Bans")]
+	[ProducesResponseType(typeof(GenericResponse<ISet<string>>), (int) HttpStatusCode.OK)]
+	public ActionResult<GenericResponse<ISet<string>>> BansGet() => Ok(new GenericResponse<ISet<string>>(ApiAuthenticationMiddleware.GetCurrentlyBannedIPs().Select(static ip => ip.ToString()).ToHashSet()));
+}

--- a/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
@@ -51,7 +51,7 @@ public sealed class IPCController : ArchiController {
 	[HttpDelete("Bans/{ipAddress:required}")]
 	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
 	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	public async Task<ActionResult<GenericResponse>> BansDeleteSpecific(string ipAddress) {
+	public ActionResult<GenericResponse> BansDeleteSpecific(string ipAddress) {
 		if (string.IsNullOrEmpty(ipAddress)) {
 			throw new ArgumentNullException(nameof(ipAddress));
 		}
@@ -60,7 +60,7 @@ public sealed class IPCController : ArchiController {
 			return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorIsInvalid, nameof(ipAddress))));
 		}
 
-		bool result = await ApiAuthenticationMiddleware.UnbanIP(remoteAddress).ConfigureAwait(false);
+		bool result = ApiAuthenticationMiddleware.UnbanIP(remoteAddress);
 
 		if (!result) {
 			return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorIPNotBanned, ipAddress)));

--- a/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/IPCController.cs
@@ -35,7 +35,7 @@ namespace ArchiSteamFarm.IPC.Controllers.Api;
 [Route("Api/IPC")]
 public sealed class IPCController : ArchiController {
 	/// <summary>
-	///     Clears the list of all IP addresses currently blocked by ASFs IPC module - Possible side effects include the removal of VAC bans
+	///     Clears the list of all IP addresses currently blocked by ASFs IPC module
 	/// </summary>
 	[HttpDelete("Bans")]
 	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]

--- a/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
+++ b/ArchiSteamFarm/IPC/Integration/ApiAuthenticationMiddleware.cs
@@ -24,6 +24,7 @@ using MvcNewtonsoftJsonOptions = Microsoft.AspNetCore.Mvc.MvcJsonOptions;
 #endif
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
@@ -88,7 +89,45 @@ internal sealed class ApiAuthenticationMiddleware {
 		await context.Response.WriteJsonAsync(new GenericResponse<StatusCodeResponse>(false, statusCodeResponse), jsonOptions.Value.SerializerSettings).ConfigureAwait(false);
 	}
 
-	private static void ClearFailedAuthorizations(object? state = null) => FailedAuthorizations.Clear();
+	internal static void ClearFailedAuthorizations(object? state = null) => FailedAuthorizations.Clear();
+
+	internal static HashSet<IPAddress> GetCurrentlyBannedIPs() => FailedAuthorizations.Where(static kv => kv.Value >= MaxFailedAuthorizationAttempts).Select(static kv => kv.Key).ToHashSet();
+
+	internal static async Task<bool> UnbanIP(IPAddress ipAddress) {
+		ArgumentNullException.ThrowIfNull(ipAddress);
+
+		if (!FailedAuthorizations.TryGetValue(ipAddress, out byte attempts) || (attempts < MaxFailedAuthorizationAttempts)) {
+			return false;
+		}
+
+		while (true) {
+			if (AuthorizationTasks.TryGetValue(ipAddress, out Task? task)) {
+				await task.ConfigureAwait(false);
+
+				continue;
+			}
+
+			TaskCompletionSource taskCompletionSource = new();
+
+			if (!AuthorizationTasks.TryAdd(ipAddress, taskCompletionSource.Task)) {
+				continue;
+			}
+
+			try {
+				bool hasFailedAuthorizations = FailedAuthorizations.TryGetValue(ipAddress, out attempts);
+
+				if (!hasFailedAuthorizations || (attempts < MaxFailedAuthorizationAttempts)) {
+					return false;
+				}
+
+				return FailedAuthorizations.TryRemove(ipAddress, out _);
+			} finally {
+				AuthorizationTasks.TryRemove(ipAddress, out _);
+
+				taskCompletionSource.SetResult();
+			}
+		}
+	}
 
 	private async Task<(HttpStatusCode StatusCode, bool Permanent)> GetAuthenticationStatus(HttpContext context) {
 		ArgumentNullException.ThrowIfNull(context);

--- a/ArchiSteamFarm/Localization/Strings.Designer.cs
+++ b/ArchiSteamFarm/Localization/Strings.Designer.cs
@@ -982,6 +982,15 @@ namespace ArchiSteamFarm.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The IP address {0} is not banned!.
+        /// </summary>
+        public static string ErrorIPNotBanned {
+            get {
+                return ResourceManager.GetString("ErrorIPNotBanned", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0} is empty!.
         /// </summary>
         public static string ErrorIsEmpty {

--- a/ArchiSteamFarm/Localization/Strings.resx
+++ b/ArchiSteamFarm/Localization/Strings.resx
@@ -742,5 +742,6 @@ Process uptime: {1}</value>
 	</data>
 	<data name="ErrorIPNotBanned" xml:space="preserve">
 		<value>The IP address {0} is not banned!</value>
+		<comment>{0} will be replaced by an IP address which was requested to be unbanned from using IPC</comment>
 	</data>
 </root>

--- a/ArchiSteamFarm/Localization/Strings.resx
+++ b/ArchiSteamFarm/Localization/Strings.resx
@@ -740,4 +740,7 @@ Process uptime: {1}</value>
 		<value>Please enter your cryptkey: </value>
 		<comment>Please note that this translation should end with space</comment>
 	</data>
+	<data name="ErrorIPNotBanned" xml:space="preserve">
+		<value>The IP address {0} is not banned!</value>
+	</data>
 </root>


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

Adds `GET /Api/IPC/Bans`, `DELETE /Api/IPC/Bans` and `DELETE /Api/IPC/Bans/{ipAddress}` to manage IPC bans via IPC (this is useful e.g. if your phones IP address got banned and you want to unban it from your PC).

## Additional info

Thank you in advance for considering the inclusion of this merge request.