### PR TITLE
Ignore in-tree www directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # Ignore all files in custom in-tree config directory (if exists)
 ArchiSteamFarm/config
 
+# Ignore all files in custom in-tree www directory (if exists)
+ArchiSteamFarm/www
+
 # Ignore private SNK key (if exists)
 resources/ArchiSteamFarm.snk
 


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

While debugging one might have a pre-compiled version of [ASF-ui](https://github.com/JustArchiNET/ASF-ui/) in their source tree, the same way a `config` directory might be in there. It bothers me that I have to make sure to not add it every time I want to add files to a commit instead of being able to just say `git add .`. This merge request fixes that by adding the `www` directory to the `.gitignore` file the same way it is already done for the `config` directory.

## Additional info

Thank you in advance for considering the inclusion of this merge request.
