### PR TITLE
Enable steamapis.com support on inventory loads

### DIFF
--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -180,7 +180,7 @@ public sealed class ArchiWebHandler : IDisposable {
 						await Task.Delay(rateLimitingDelay).ConfigureAwait(false);
 					}
                     if (useSteamApis) {
-                        Uri request = new(SteamApisURL, $"/steam/inventory/{steamID}/{appID}/{contextID}?count={count}&l=english{(startAssetID > 0 ? $"&start_assetid={startAssetID}" : "")}&api_key={Bot.BotConfig.SteamApisToken}");
+                        Uri request = new(SteamApisURL, $"/steam/inventory/{steamID}/{appID}/{contextID}?l=english{(startAssetID > 0 ? $"&start_assetid={startAssetID}" : "")}&api_key={Bot.BotConfig.SteamApisToken}");
                         response = await WebBrowser.UrlGetToJsonObject<InventoryResponse>(request, requestOptions: WebBrowser.ERequestOptions.ReturnClientErrors | WebBrowser.ERequestOptions.ReturnServerErrors | WebBrowser.ERequestOptions.AllowInvalidBodyOnErrors, rateLimitingDelay: rateLimitingDelay).ConfigureAwait(false);
                     } else {
                         Uri request = new(SteamCommunityURL, $"/inventory/{steamID}/{appID}/{contextID}?count={count}&l=english{(startAssetID > 0 ? $"&start_assetid={startAssetID}" : "")}");

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -113,6 +113,9 @@ public sealed class BotConfig {
 	[PublicAPI]
 	public const string? DefaultSteamTradeToken = null;
 
+    [PublicAPI]
+	public const string? DefaultSteamApisToken = null;
+
 	[PublicAPI]
 	public const ETradingPreferences DefaultTradingPreferences = ETradingPreferences.None;
 
@@ -266,6 +269,10 @@ public sealed class BotConfig {
 	[UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026:RequiresUnreferencedCode", Justification = "This is optional, supportive attribute, we don't care if it gets trimmed or not")]
 	public string? SteamTradeToken { get; private set; } = DefaultSteamTradeToken;
 
+    [JsonProperty]
+    [UnconditionalSuppressMessage("AssemblyLoadTrimming", "IL2026:RequiresUnreferencedCode", Justification = "This is optional, supportive attribute, we don't care if it gets trimmed or not")]
+    public string? SteamApisToken { get; private set; } = DefaultSteamApisToken;
+
 	[JsonProperty(Required = Required.DisallowNull)]
 	public ImmutableDictionary<ulong, EAccess> SteamUserPermissions { get; private set; } = DefaultSteamUserPermissions;
 
@@ -401,6 +408,9 @@ public sealed class BotConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSteamTradeToken() => !Saving || (SteamTradeToken != DefaultSteamTradeToken);
+
+    [UsedImplicitly]
+	public bool ShouldSerializeSteamApisToken() => !Saving || (SteamApisToken != DefaultSteamApisToken);
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSteamUserPermissions() => !Saving || ((SteamUserPermissions != DefaultSteamUserPermissions) && ((SteamUserPermissions.Count != DefaultSteamUserPermissions.Count) || SteamUserPermissions.Except(DefaultSteamUserPermissions).Any()));


### PR DESCRIPTION
## Disclaimer
This **PR is NOT meant to be merged** into `main` branch, as I consider this approach out-of-scope for this project.

It must be considered as a public PoC (proof of concept) to show up how to bypass current inventory load limits by using a built-in (paid 3rd-party) proxy pool, as stated by `jalapenio33333#7322` on `#asf-development` discord channel.

These are my first lines of C# code so please if someone is going to use this,.. do it under your responsibility. 
Thank you so much to **[Super Errorka](https://steamcommunity.com/id/supererrorka/)** for the hints!

Neither me, nor ArchiSteamFarm project is affiliated with SteamApis(dot)com, or any of their partners.

## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [X] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [X] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [ ] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [X] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] I have added tests to cover my changes, wherever they are necessary.
- [X] All new and existing tests pass.

## Changes

### New functionality
Add [steamapis.com](https://steamapis.com/) (by @pepzwee) integration for loading inventories to workaround #2728 issue.
<!-- Please describe below, what new functionality was added. -->

### Changed functionality

Other people inventories are loaded using [steamapis.com](https://steamapis.com/) proxy pool if `SteamApisToken` config property is set at `BotName.json` config file. Loading own inventory still use regular [steamcommunity.com](https://steamcommunity.com/) endpoint provided by Valve, as well as, other people inventories does when `SteamApisToken` config property is not provided.

### Removed functionality

None

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
![](https://i.imgflip.com/72vsh5.jpg)

