### PR TITLE
Add support for request compression

### DIFF
--- a/ArchiSteamFarm.OfficialPlugins.ItemsMatcher/Backend.cs
+++ b/ArchiSteamFarm.OfficialPlugins.ItemsMatcher/Backend.cs
@@ -69,7 +69,7 @@ internal static class Backend {
 
 		AnnouncementRequest data = new(ASF.GlobalDatabase?.Identifier ?? Guid.NewGuid(), steamID, tradeToken, inventory, acceptedMatchableTypes, totalInventoryCount, matchEverything, ASF.GlobalConfig?.MaxTradeHoldDuration ?? GlobalConfig.DefaultMaxTradeHoldDuration, nickname, avatarHash);
 
-		return await webBrowser.UrlPost(request, data: data, requestOptions: WebBrowser.ERequestOptions.ReturnRedirections | WebBrowser.ERequestOptions.ReturnClientErrors).ConfigureAwait(false);
+		return await webBrowser.UrlPost(request, data: data, requestOptions: WebBrowser.ERequestOptions.ReturnRedirections | WebBrowser.ERequestOptions.ReturnClientErrors | WebBrowser.ERequestOptions.CompressRequest).ConfigureAwait(false);
 	}
 
 	internal static async Task<(HttpStatusCode StatusCode, ImmutableHashSet<ListedUser> Users)?> GetListedUsersForMatching(Guid licenseID, Bot bot, WebBrowser webBrowser, IReadOnlyCollection<Asset> inventory, IReadOnlyCollection<Asset.EType> acceptedMatchableTypes) {
@@ -96,7 +96,7 @@ internal static class Backend {
 
 		InventoriesRequest data = new(ASF.GlobalDatabase?.Identifier ?? Guid.NewGuid(), bot.SteamID, inventory, acceptedMatchableTypes);
 
-		ObjectResponse<GenericResponse<ImmutableHashSet<ListedUser>>>? response = await webBrowser.UrlPostToJsonObject<GenericResponse<ImmutableHashSet<ListedUser>>, InventoriesRequest>(request, headers, data, requestOptions: WebBrowser.ERequestOptions.ReturnClientErrors | WebBrowser.ERequestOptions.AllowInvalidBodyOnErrors).ConfigureAwait(false);
+		ObjectResponse<GenericResponse<ImmutableHashSet<ListedUser>>>? response = await webBrowser.UrlPostToJsonObject<GenericResponse<ImmutableHashSet<ListedUser>>, InventoriesRequest>(request, headers, data, requestOptions: WebBrowser.ERequestOptions.ReturnClientErrors | WebBrowser.ERequestOptions.AllowInvalidBodyOnErrors | WebBrowser.ERequestOptions.CompressRequest).ConfigureAwait(false);
 
 		if (response == null) {
 			return null;
@@ -113,6 +113,6 @@ internal static class Backend {
 
 		HeartBeatRequest data = new(ASF.GlobalDatabase?.Identifier ?? Guid.NewGuid(), bot.SteamID);
 
-		return await webBrowser.UrlPost(request, data: data, requestOptions: WebBrowser.ERequestOptions.ReturnRedirections | WebBrowser.ERequestOptions.ReturnClientErrors).ConfigureAwait(false);
+		return await webBrowser.UrlPost(request, data: data, requestOptions: WebBrowser.ERequestOptions.ReturnRedirections | WebBrowser.ERequestOptions.ReturnClientErrors | WebBrowser.ERequestOptions.CompressRequest).ConfigureAwait(false);
 	}
 }

--- a/ArchiSteamFarm/Web/CompressedContent.cs
+++ b/ArchiSteamFarm/Web/CompressedContent.cs
@@ -62,9 +62,9 @@ internal sealed class CompressedContent : StreamContent {
 		ArgumentNullException.ThrowIfNull(output);
 
 #if NETFRAMEWORK
-		return (new GZipStream(output, CompressionLevel.Optimal, true), "gzip");
+		return (new GZipStream(output, CompressionLevel.Fastest, true), "gzip");
 #else
-		return (new BrotliStream(output, CompressionLevel.SmallestSize, true), "br");
+		return (new BrotliStream(output, CompressionLevel.Fastest, true), "br");
 #endif
 	}
 }

--- a/ArchiSteamFarm/Web/CompressedContent.cs
+++ b/ArchiSteamFarm/Web/CompressedContent.cs
@@ -1,0 +1,70 @@
+//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// |
+// Copyright 2015-2023 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace ArchiSteamFarm.Web;
+
+internal sealed class CompressedContent : StreamContent {
+	private CompressedContent(Stream content) : base(content) => ArgumentNullException.ThrowIfNull(content);
+
+	internal static async Task<CompressedContent> FromHttpContent(HttpContent content) {
+		ArgumentNullException.ThrowIfNull(content);
+
+		// We're going to create compressed stream and copy original content to it
+		MemoryStream compressionOutput = new();
+
+		(Stream compressionInput, string contentEncoding) = GetBestSupportedCompressionMethod(compressionOutput);
+
+		await using (compressionInput.ConfigureAwait(false)) {
+			await content.CopyToAsync(compressionInput).ConfigureAwait(false);
+		}
+
+		// Reset the position back to 0, so HttpClient can read it again
+		compressionOutput.Position = 0;
+
+		CompressedContent result = new(compressionOutput);
+
+		foreach ((string? key, IEnumerable<string>? value) in content.Headers) {
+			result.Headers.Add(key, value);
+		}
+
+		// Inform the server that we're sending compressed data
+		result.Headers.ContentEncoding.Add(contentEncoding);
+
+		return result;
+	}
+
+	private static (Stream CompressionInput, string ContentEncoding) GetBestSupportedCompressionMethod(Stream output) {
+		ArgumentNullException.ThrowIfNull(output);
+
+#if NETFRAMEWORK
+		return (new GZipStream(output, CompressionLevel.Optimal, true), "gzip");
+#else
+		return (new BrotliStream(output, CompressionLevel.SmallestSize, true), "br");
+#endif
+	}
+}

--- a/ArchiSteamFarm/Web/WebBrowser.cs
+++ b/ArchiSteamFarm/Web/WebBrowser.cs
@@ -24,6 +24,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -825,6 +826,39 @@ public sealed class WebBrowser : IDisposable {
 
 							break;
 					}
+
+					// Compress the request if caller specified it, so he knows that the server supports it, and the content is not compressed yet
+					if (requestOptions.HasFlag(ERequestOptions.CompressRequest) && (requestMessage.Content.Headers.ContentEncoding.Count == 0)) {
+						HttpContent originalContent = requestMessage.Content;
+
+						// We're going to create compressed stream and copy original content to it
+						MemoryStream compressionOutput = new();
+
+#pragma warning disable CA2000 // False positive, we're actually wrapping it in the using clause below exactly for that purpose
+						BrotliStream compressionInput = new(compressionOutput, CompressionLevel.SmallestSize, true);
+#pragma warning restore CA2000 // False positive, we're actually wrapping it in the using clause below exactly for that purpose
+
+						await using (compressionInput.ConfigureAwait(false)) {
+							await originalContent.CopyToAsync(compressionInput).ConfigureAwait(false);
+						}
+
+						// Reset the position back to 0, so HttpClient can read it again
+						compressionOutput.Position = 0;
+
+						requestMessage.Content = new StreamContent(compressionOutput);
+
+						foreach ((string? key, IEnumerable<string>? value) in originalContent.Headers) {
+							requestMessage.Content.Headers.Add(key, value);
+						}
+
+						if (data is not HttpContent) {
+							// We don't need to keep old HttpContent around anymore, help GC
+							originalContent.Dispose();
+						}
+
+						// Inform the server that we're sending compressed data
+						requestMessage.Content.Headers.ContentEncoding.Add("br");
+					}
 				}
 
 				if (referer != null) {
@@ -957,6 +991,7 @@ public sealed class WebBrowser : IDisposable {
 		ReturnServerErrors = 2,
 		ReturnRedirections = 4,
 		AllowInvalidBodyOnSuccess = 8,
-		AllowInvalidBodyOnErrors = 16
+		AllowInvalidBodyOnErrors = 16,
+		CompressRequest = 32
 	}
 }


### PR DESCRIPTION
Now this is pretty rare, in general web browsers (clients) do not compress their payloads, because they don't know if the server will understand them. On top of that, the requests are usually small, and it's the responses that are big, those are already compressed since the client tells the server through `Accept-Encoding` what he understands, and the server can decide to reply in one of the supported compressed formats.

We have different situation, it's ASF which is announcing to the server with huge, sometimes going into 30 MB+ data of items, for announcing as well as matching. We can assume that the server understands us, since we're in fact in charge of it, and instruct ASF to compress the data in the request payload, yielding huge gains.

On my machine, example 25 MB json can get down to 3.7 MB spending just 272 ms of CPU time using fastest compression, and maximum is 1.9 MB spending 33.398 seconds. We could dedicate additional time to further offload the server, but it's not worth it, decreasing the amount of data sent by 6-7x is already huge enough, and with just 272ms of CPU time, completely transparent. I'd even argue that the CPU time spent on pushing that 25 MB data through the link could be bigger than the CPU time spent on compressing it in advance.

This won't just help the server by decreasing its bandwidth used, it'll also help people with slower internet speeds to push that data through their own links.