### PR TITLE
 Periodically check for outstanding trades. Closes #2871 

### DIFF
--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -114,6 +114,9 @@ public sealed class BotConfig {
 	public const string? DefaultSteamTradeToken = null;
 
 	[PublicAPI]
+	public const byte DefaultTradeCheckPeriod = 0;
+
+	[PublicAPI]
 	public const ETradingPreferences DefaultTradingPreferences = ETradingPreferences.None;
 
 	[PublicAPI]
@@ -270,6 +273,10 @@ public sealed class BotConfig {
 	public ImmutableDictionary<ulong, EAccess> SteamUserPermissions { get; private set; } = DefaultSteamUserPermissions;
 
 	[JsonProperty(Required = Required.DisallowNull)]
+	[Range(byte.MinValue, byte.MaxValue)]
+	public byte TradeCheckPeriod { get; private set; } = DefaultTradeCheckPeriod;
+
+	[JsonProperty(Required = Required.DisallowNull)]
 	public ETradingPreferences TradingPreferences { get; private set; } = DefaultTradingPreferences;
 
 	[JsonProperty(Required = Required.DisallowNull)]
@@ -404,6 +411,10 @@ public sealed class BotConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeSteamUserPermissions() => !Saving || ((SteamUserPermissions != DefaultSteamUserPermissions) && ((SteamUserPermissions.Count != DefaultSteamUserPermissions.Count) || SteamUserPermissions.Except(DefaultSteamUserPermissions).Any()));
+
+	[UsedImplicitly]
+	public bool ShouldSerializeTradeCheckPeriod() => !Saving || (TradeCheckPeriod != DefaultTradeCheckPeriod);
+
 
 	[UsedImplicitly]
 	public bool ShouldSerializeTradingPreferences() => !Saving || (TradingPreferences != DefaultTradingPreferences);

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -114,7 +114,7 @@ public sealed class BotConfig {
 	public const string? DefaultSteamTradeToken = null;
 
 	[PublicAPI]
-	public const byte DefaultTradeCheckPeriod = 0;
+	public const byte DefaultTradeCheckPeriod = 60;
 
 	[PublicAPI]
 	public const ETradingPreferences DefaultTradingPreferences = ETradingPreferences.None;


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Added check for outstanding trades by timer, disabled by default. See #2871 for details.
Added new **bot** configuration parameter `TradeCheckPeriod`, that sets period for checking of outstanding trades in minutes.

### New functionality

When `TradeCheckPeriod` bot parameter set to non-zero value - ASF checks for outstanding trades every `TradeCheckPeriod` minutes.

### Changed functionality

with default values no functionality affected.

### Removed functionality

none

## Additional info

My draft of parameter description for adding to the wiki, Configuration->Bot config section (please check this before adding, I'm not good at wording):

```
### `TradeCheckPeriod`

`byte` type with default value of `60`. Normally ASF handles incoming trade offers right after receiving notification about one, but sometimes because of steam glitches it can't do it at that time, and such trade offers remain ignored until next trade notification or bot restart occurs, which may lead to trades becoming cancelled or items not available at that later time. If this parameter is set to non-zero value, ASF will additionally check for such outstanding trades every `TradeCheckPeriod` minutes. Default value is selected with balance between additional requests to steam servers and losing incoming trades in mind. However, if you are just using ASF to farm cards, and don't plan to automatically process any incoming trades, you may set it to 0, to disable this feature completely. On the other hand, if your bot participates in public [ASF's STM listing](https://github.com/JustArchiNET/ArchiSteamFarm/wiki/ItemsMatcherPlugin#publiclisting) or provides other automated services as a trade bot you may want to decrease this parameter to 10\~15 minutes, to process all trades in a timely manner.

```
