### PR TITLE
Check if bot online before checking for outstanding trades. Bugfix for #2871

### DIFF
--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -3195,7 +3195,11 @@ public sealed class Bot : IAsyncDisposable, IDisposable {
 		await CheckOccupationStatus().ConfigureAwait(false);
 	}
 
-	private void OnTradeCheckTimer(object? state = null) => Utilities.InBackground(Trading.OnNewTrade);
+	private void OnTradeCheckTimer(object? state = null) {
+		if (IsConnectedAndLoggedOn) {
+			Utilities.InBackground(Trading.OnNewTrade);
+		}
+	}
 
 	private void OnUserNotifications(UserNotificationsCallback callback) {
 		ArgumentNullException.ThrowIfNull(callback);


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes
Fixes an error introduced in #2871 - offline bots were trying to check for oustanding trades too.

### New functionality

just a fix, no new functionality

### Changed functionality

Offline bots don't try to check for outstanding trades.

### Removed functionality

none

## Additional info

Sorry about that.
