### PR TITLE
Minimize chances of TooManyOffersSent during MatchActively

### DIFF
--- a/ArchiSteamFarm.OfficialPlugins.ItemsMatcher/RemoteCommunication.cs
+++ b/ArchiSteamFarm.OfficialPlugins.ItemsMatcher/RemoteCommunication.cs
@@ -51,7 +51,7 @@ namespace ArchiSteamFarm.OfficialPlugins.ItemsMatcher;
 internal sealed class RemoteCommunication : IAsyncDisposable, IDisposable {
 	private const string MatchActivelyTradeOfferIDsStorageKey = $"{nameof(ItemsMatcher)}-{nameof(MatchActively)}-TradeOfferIDs";
 	private const byte MaxAnnouncementTTL = 60; // Maximum amount of minutes we can wait if the next announcement doesn't happen naturally
-	private const byte MaxTradeOffersActive = 10; // The actual upper limit is 30, but we should use lower amount to allow some bots to react before we hit the maximum allowed
+	private const byte MaxTradeOffersActive = 5; // The actual upper limit is 30, but we should use lower amount to allow some bots to react before we hit the maximum allowed
 	private const byte MinAnnouncementTTL = 5; // Minimum amount of minutes we must wait before the next Announcement
 	private const byte MinHeartBeatTTL = 10; // Minimum amount of minutes we must wait before sending next HeartBeat
 	private const byte MinimumSteamGuardEnabledDays = 15; // As imposed by Steam limits


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality
N/A
<!-- Please describe below, what new functionality was added. -->

### Changed functionality
Allow just 5 active offers at once so we minimize the changes of getting:
```
SendTradeOffer() Failed due to error: You have sent too many trade offers, or have too many outstanding trade offers with User. Please cancel some before sending more.
```
... during match actively.
<!-- Please describe below, what old functionality was changed. -->

### Removed functionality
N/A
<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
