### PR TITLE
Allow plugins to override blacklisted trades

### DIFF
--- a/ArchiSteamFarm/Steam/Exchange/Trading.cs
+++ b/ArchiSteamFarm/Steam/Exchange/Trading.cs
@@ -445,6 +445,7 @@ public sealed class Trading : IDisposable {
 		switch (result) {
 			case ParseTradeResult.EResult.Ignored:
 			case ParseTradeResult.EResult.Rejected:
+			case ParseTradeResult.EResult.Blacklisted:
 				bool accept = await PluginsCore.OnBotTradeOffer(Bot, tradeOffer).ConfigureAwait(false);
 
 				if (accept) {


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Allows plugins to review and accept trades from blacklisted users. Main reason for this change is to allow blacklisting master/owner account(s), so that instead of all trades accepted unconditionally ASF only accepted trades according to logic in plugins. This is a follow-up for https://github.com/JustArchiNET/ArchiSteamFarm/commit/1cb1bd3d67508366101ae61226c93b91526350fb# ![slowpoke](https://cdn.discordapp.com/emojis/960826231740330045.webp?size=32&quality=lossless)

### New functionality

Allows plugins to review and accept trades from blacklisted users.

### Changed functionality

Allows plugins to review and accept trades from blacklisted users.

### Removed functionality

none

## Additional info

Main reason for this change is to allow blacklisting master/owner account(s), so that instead of all trades accepted unconditionally asf only accepted trades according to logic in plugins.
