### PR TITLE
Add GitHub proxy for Chinese users

### DIFF
--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -313,7 +313,7 @@ public static class ASF {
 
 			try {
 				Uri downloadURL = CultureInfo.CurrentCulture.Equals(CultureInfo.GetCultureInfo("zh-CN"))
-					? new(SharedInfo.GithubProxyURL + binaryAsset.DownloadURL.AbsoluteUri)
+					? new Uri(SharedInfo.GithubProxyURL + binaryAsset.DownloadURL.AbsoluteUri)
 					: binaryAsset.DownloadURL;
 				response = await WebBrowser.UrlGetToBinary(downloadURL, progressReporter: progressReporter).ConfigureAwait(false);
 			} finally {

--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -312,7 +312,10 @@ public static class ASF {
 			BinaryResponse? response;
 
 			try {
-				response = await WebBrowser.UrlGetToBinary(binaryAsset.DownloadURL!, progressReporter: progressReporter).ConfigureAwait(false);
+				Uri downloadURL = CultureInfo.CurrentCulture.Equals(CultureInfo.GetCultureInfo("zh-CN"))
+					? new(SharedInfo.GithubProxyURL + binaryAsset.DownloadURL.AbsoluteUri)
+					: binaryAsset.DownloadURL;
+				response = await WebBrowser.UrlGetToBinary(downloadURL, progressReporter: progressReporter).ConfigureAwait(false);
 			} finally {
 				progressReporter.ProgressChanged -= OnProgressChanged;
 			}

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -45,6 +45,7 @@ public static class SharedInfo {
 	internal const string EnvironmentVariableCryptKeyFile = $"{EnvironmentVariableCryptKey}_FILE";
 	internal const string EnvironmentVariableNetworkGroup = $"{ASF}_NETWORK_GROUP";
 	internal const string EnvironmentVariablePath = $"{ASF}_PATH";
+	internal const string GithubProxyURL = "https://ghproxy.com/";
 	internal const string GithubReleaseURL = $"https://api.github.com/repos/{GithubRepo}/releases";
 	internal const string GithubRepo = $"JustArchiNET/{AssemblyName}";
 	internal const string GlobalConfigFileName = $"{ASF}{JsonConfigExtension}";


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] I have added tests to cover my changes, wherever they are necessary.
- [ ] All new and existing tests pass.

## Changes

### New functionality

When it is detected that the user's system culture is `zh-CN`, add GitHub proxy into the download url of new release. This can speed up the GitHub release download speed and is not limited by the network environment.

### Changed functionality

> `ASF#Update`

### Removed functionality

_None_

## Additional info

Due to China's GFW, GitHub is not readily available. We can add the proxy to ensure usability. 

The proxy's repo: [hunshcn/gh-proxy](https://github.com/hunshcn/gh-proxy)
