### PR TITLE
Switch to different cat api in example plugin

### DIFF
--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
@@ -20,6 +20,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Web;
 using ArchiSteamFarm.Web.Responses;
@@ -30,15 +31,15 @@ namespace ArchiSteamFarm.CustomPlugins.ExamplePlugin;
 // You've always wanted from your ASF to post cats, right? Now is your chance!
 // P.S. The code is almost 1:1 copy from the one I use in ArchiBot, you can thank me later
 internal static class CatAPI {
-	private const string URL = "https://aws.random.cat";
+	private const string URL = "https://api.thecatapi.com";
 
 	internal static async Task<Uri?> GetRandomCatURL(WebBrowser webBrowser) {
 		ArgumentNullException.ThrowIfNull(webBrowser);
 
-		Uri request = new($"{URL}/meow");
+		Uri request = new($"{URL}/v1/images/search");
 
-		ObjectResponse<MeowResponse>? response = await webBrowser.UrlGetToJsonObject<MeowResponse>(request).ConfigureAwait(false);
+		ObjectResponse<List<MeowResponse>>? response = await webBrowser.UrlGetToJsonObject<List<MeowResponse>>(request).ConfigureAwait(false);
 
-		return response?.Content?.URL;
+		return response?.Content?[0].URL;
 	}
 }

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Web;
 using ArchiSteamFarm.Web.Responses;
@@ -38,8 +39,8 @@ internal static class CatAPI {
 
 		Uri request = new($"{URL}/v1/images/search");
 
-		ObjectResponse<List<MeowResponse>>? response = await webBrowser.UrlGetToJsonObject<List<MeowResponse>>(request).ConfigureAwait(false);
+		ObjectResponse<ImmutableList<MeowResponse>>? response = await webBrowser.UrlGetToJsonObject<ImmutableList<MeowResponse>>(request).ConfigureAwait(false);
 
-		return response?.Content?[0].URL;
+		return response?.Content?.Count > 0 ? response?.Content?[0].URL : null;
 	}
 }

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatAPI.cs
@@ -20,8 +20,8 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Web;
 using ArchiSteamFarm.Web.Responses;
@@ -41,6 +41,6 @@ internal static class CatAPI {
 
 		ObjectResponse<ImmutableList<MeowResponse>>? response = await webBrowser.UrlGetToJsonObject<ImmutableList<MeowResponse>>(request).ConfigureAwait(false);
 
-		return response?.Content?.Count > 0 ? response?.Content?[0].URL : null;
+		return response?.Content?.FirstOrDefault()?.URL;
 	}
 }

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
@@ -27,11 +27,16 @@ namespace ArchiSteamFarm.CustomPlugins.ExamplePlugin;
 
 #pragma warning disable CA1812 // False positive, the class is used during json deserialization
 [SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
-internal sealed class MeowResponse {
-	[JsonProperty("file", Required = Required.Always)]
-	internal readonly Uri URL = null!;
 
-	[JsonConstructor]
-	private MeowResponse() { }
+internal sealed class MeowResponse {
+	[JsonProperty("id")]
+	public string Id { get; set; }
+	[JsonProperty("url", Required = Required.Always)]
+	internal readonly Uri URL = null!;
+	[JsonProperty("width")]
+	public int Width { get; set; }
+	[JsonProperty("height")]
+	public int Height { get; set; }
 }
+
 #pragma warning restore CA1812 // False positive, the class is used during json deserialization

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
@@ -27,19 +27,11 @@ namespace ArchiSteamFarm.CustomPlugins.ExamplePlugin;
 
 #pragma warning disable CA1812 // False positive, the class is used during json deserialization
 [SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
-
 internal sealed class MeowResponse {
-	[JsonProperty("id")]
-	internal string? Id { get; set; }
-	[JsonProperty("url", Required = Required.Always)]
+	[JsonProperty("file", Required = Required.Always)]
 	internal readonly Uri URL = null!;
-	[JsonProperty("width")]
-	internal int? Width { get; set; }
-	[JsonProperty("height")]
-	internal int? Height { get; set; }
 
 	[JsonConstructor]
 	private MeowResponse() { }
 }
-
 #pragma warning restore CA1812 // False positive, the class is used during json deserialization

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
@@ -30,13 +30,16 @@ namespace ArchiSteamFarm.CustomPlugins.ExamplePlugin;
 
 internal sealed class MeowResponse {
 	[JsonProperty("id")]
-	public string Id { get; set; }
+	internal string? Id { get; set; }
 	[JsonProperty("url", Required = Required.Always)]
 	internal readonly Uri URL = null!;
 	[JsonProperty("width")]
-	public int Width { get; set; }
+	internal int? Width { get; set; }
 	[JsonProperty("height")]
-	public int Height { get; set; }
+	internal int? Height { get; set; }
+
+	[JsonConstructor]
+	private MeowResponse() { }
 }
 
 #pragma warning restore CA1812 // False positive, the class is used during json deserialization

--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/MeowResponse.cs
@@ -28,7 +28,7 @@ namespace ArchiSteamFarm.CustomPlugins.ExamplePlugin;
 #pragma warning disable CA1812 // False positive, the class is used during json deserialization
 [SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
 internal sealed class MeowResponse {
-	[JsonProperty("file", Required = Required.Always)]
+	[JsonProperty("url", Required = Required.Always)]
 	internal readonly Uri URL = null!;
 
 	[JsonConstructor]


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Cat api used in example plugin does not seem to respond anymore, So to keep example plugin operational I switched to different public api.

### New functionality
None
<!-- Please describe below, what new functionality was added. -->

### Changed functionality
Lol, none
<!-- Please describe below, what old functionality was changed. -->

### Removed functionality
Why would I?
<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
Archi pls