### PR TITLE
Closes #3017

### DIFF
--- a/ArchiSteamFarm/Collections/ObservableConcurrentDictionary.cs
+++ b/ArchiSteamFarm/Collections/ObservableConcurrentDictionary.cs
@@ -39,6 +39,9 @@ public sealed class ObservableConcurrentDictionary<TKey, TValue> : IDictionary<T
 
 	public bool IsReadOnly => false;
 
+	[PublicAPI]
+	public ICollection<TKey> Keys => BackingDictionary.Keys;
+
 	[JsonProperty(Required = Required.DisallowNull)]
 	private readonly ConcurrentDictionary<TKey, TValue> BackingDictionary = new();
 

--- a/ArchiSteamFarm/Collections/ObservableConcurrentDictionary.cs
+++ b/ArchiSteamFarm/Collections/ObservableConcurrentDictionary.cs
@@ -111,6 +111,15 @@ public sealed class ObservableConcurrentDictionary<TKey, TValue> : IDictionary<T
 	bool IDictionary<TKey, TValue>.TryGetValue(TKey key, out TValue value) => BackingDictionary.TryGetValue(key, out value!);
 
 	[PublicAPI]
+	public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory) {
+		TValue result = BackingDictionary.AddOrUpdate(key, addValue, updateValueFactory);
+
+		OnModified?.Invoke(this, EventArgs.Empty);
+
+		return result;
+	}
+
+	[PublicAPI]
 	public bool TryAdd(TKey key, TValue value) {
 		if (!BackingDictionary.TryAdd(key, value)) {
 			return false;

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -1568,6 +1568,8 @@ public sealed class Bot : IAsyncDisposable, IDisposable {
 			ASF.ArchiLogger.LogGenericDebug($"{databaseFilePath}: {JsonConvert.SerializeObject(botDatabase, Formatting.Indented)}");
 		}
 
+		botDatabase.PerformMaintenance();
+
 		Bot bot;
 
 		await BotsSemaphore.WaitAsync().ConfigureAwait(false);

--- a/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
+++ b/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
@@ -1204,7 +1204,12 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		if (GamesToFarm.Count == 0) {
 			ShouldResumeFarming = false;
 
-			return false;
+			// Allow changing to risky algorithm only if we failed at least some badge pages and we have the prop enabled
+			if (allTasksSucceeded || !Bot.BotConfig.EnableRiskyCardsDiscovery) {
+				return false;
+			}
+
+			return await IsAnythingToFarmRisky().ConfigureAwait(false);
 		}
 
 		ShouldResumeFarming = true;

--- a/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
+++ b/ArchiSteamFarm/Steam/Cards/CardsFarmer.cs
@@ -34,9 +34,11 @@ using ArchiSteamFarm.Collections;
 using ArchiSteamFarm.Core;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.Plugins;
+using ArchiSteamFarm.Steam.Data;
 using ArchiSteamFarm.Steam.Integration;
 using ArchiSteamFarm.Steam.Storage;
 using ArchiSteamFarm.Storage;
+using ArchiSteamFarm.Web;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using SteamKit2;
@@ -142,6 +144,7 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 	private bool ParsingScheduled;
 	private bool PermanentlyPaused;
 	private bool ShouldResumeFarming;
+	private bool ShouldSkipNewGamesIfPossible;
 
 	internal CardsFarmer(Bot bot) {
 		Bot = bot ?? throw new ArgumentNullException(nameof(bot));
@@ -223,7 +226,7 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 			// We should restart the farming if the order or efficiency of the farming could be affected by the newly-activated product
 			// The order is affected when user uses farming order that isn't independent of the game data (it could alter the order in deterministic way if the game was considered in current queue)
 			// The efficiency is affected only in complex algorithm (entirely), as it depends on hours order that is not independent (as specified above)
-			if ((Bot.BotConfig.HoursUntilCardDrops > 0) || ((Bot.BotConfig.FarmingOrders.Count > 0) && Bot.BotConfig.FarmingOrders.Any(static farmingOrder => (farmingOrder != BotConfig.EFarmingOrder.Unordered) && (farmingOrder != BotConfig.EFarmingOrder.Random)))) {
+			if (!ShouldSkipNewGamesIfPossible && ((Bot.BotConfig.HoursUntilCardDrops > 0) || ((Bot.BotConfig.FarmingOrders.Count > 0) && Bot.BotConfig.FarmingOrders.Any(static farmingOrder => (farmingOrder != BotConfig.EFarmingOrder.Unordered) && (farmingOrder != BotConfig.EFarmingOrder.Random))))) {
 				await StopFarming().ConfigureAwait(false);
 				await StartFarming().ConfigureAwait(false);
 			}
@@ -298,7 +301,7 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 
 	internal void SetInitialState(bool paused) {
 		PermanentlyPaused = Paused = paused;
-		ShouldResumeFarming = false;
+		ShouldResumeFarming = ShouldSkipNewGamesIfPossible = false;
 	}
 
 	internal async Task StartFarming() {
@@ -424,19 +427,18 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 			throw new ArgumentOutOfRangeException(nameof(hours));
 		}
 
-		ushort? cardsRemaining = await GetCardsRemaining(appID).ConfigureAwait(false);
+		Game? game = await GetGameCardsInfo(appID).ConfigureAwait(false);
 
-		switch (cardsRemaining) {
-			case null:
-				Bot.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningCouldNotCheckCardsStatus, appID, name));
+		if (game == null) {
+			Bot.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningCouldNotCheckCardsStatus, appID, name));
 
-				return;
-			case 0:
-				return;
-			default:
-				GamesToFarm.Add(new Game(appID, name, hours, cardsRemaining.Value, badgeLevel));
+			return;
+		}
 
-				break;
+		if (game.CardsRemaining > 0) {
+			Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Add(appID);
+
+			GamesToFarm.Add(new Game(appID, name, hours, game.CardsRemaining, badgeLevel));
 		}
 	}
 
@@ -495,30 +497,8 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 				continue;
 			}
 
-			if (SalesBlacklist.Contains(appID) || (ASF.GlobalConfig?.Blacklist.Contains(appID) == true) || Bot.IsBlacklistedFromIdling(appID) || (Bot.BotConfig.FarmPriorityQueueOnly && !Bot.IsPriorityIdling(appID))) {
-				// We're configured to ignore this appID, so skip it
-				continue;
-			}
-
-			bool ignored = false;
-
-			foreach (ConcurrentDictionary<uint, DateTime> sourceOfIgnoredAppIDs in SourcesOfIgnoredAppIDs) {
-				if (!sourceOfIgnoredAppIDs.TryGetValue(appID, out DateTime ignoredUntil)) {
-					continue;
-				}
-
-				if (ignoredUntil > DateTime.UtcNow) {
-					// This game is still ignored
-					ignored = true;
-
-					break;
-				}
-
-				// This game served its time as being ignored
-				sourceOfIgnoredAppIDs.TryRemove(appID, out _);
-			}
-
-			if (ignored) {
+			if (!ShouldIdle(appID)) {
+				// No point in evaluating further if we can determine that on appID alone
 				continue;
 			}
 
@@ -737,6 +717,8 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 			// Either we have decent info about appID, name, hours, cardsRemaining (cardsRemaining > 0) and level
 			// OR we strongly believe that Steam lied to us, in this case we will need to check game individually (cardsRemaining == 0)
 			if (cardsRemaining > 0) {
+				Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Add(appID);
+
 				GamesToFarm.Add(new Game(appID, name, hours, cardsRemaining, badgeLevel));
 			} else {
 				Task task = CheckGame(appID, name, hours, badgeLevel);
@@ -762,7 +744,7 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		}
 	}
 
-	private async Task CheckPage(byte page, ISet<uint> parsedAppIDs) {
+	private async Task<bool> CheckPage(byte page, ISet<uint> parsedAppIDs) {
 		if (page == 0) {
 			throw new ArgumentOutOfRangeException(nameof(page));
 		}
@@ -772,10 +754,12 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		using IDocument? htmlDocument = await Bot.ArchiWebHandler.GetBadgePage(page).ConfigureAwait(false);
 
 		if (htmlDocument == null) {
-			return;
+			return false;
 		}
 
 		await CheckPage(htmlDocument, parsedAppIDs).ConfigureAwait(false);
+
+		return true;
 	}
 
 	private async Task Farm() {
@@ -1003,16 +987,58 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		return true;
 	}
 
-	private async Task<ushort?> GetCardsRemaining(uint appID) {
+	private async Task<Game?> GetGameCardsInfo(uint appID) {
 		if (appID == 0) {
 			throw new ArgumentOutOfRangeException(nameof(appID));
 		}
 
 		using IDocument? htmlDocument = await Bot.ArchiWebHandler.GetGameCardsPage(appID).ConfigureAwait(false);
 
-		INode? progressNode = htmlDocument?.SelectSingleNode("//span[@class='progress_info_bold']");
+		if (htmlDocument == null) {
+			return null;
+		}
+
+		INode? nameNode = htmlDocument.SelectSingleNode("(//span[@class='profile_small_header_location'])[last()]");
+
+		if (nameNode == null) {
+			Bot.ArchiLogger.LogNullError(nameNode);
+
+			return null;
+		}
+
+		string name = nameNode.TextContent;
+
+		if (string.IsNullOrEmpty(name)) {
+			Bot.ArchiLogger.LogNullError(name);
+
+			return null;
+		}
+
+		INode? hoursNode = htmlDocument.SelectSingleNode("//div[@class='badge_title_stats_playtime']");
+
+		if (hoursNode == null) {
+			Bot.ArchiLogger.LogNullError(hoursNode);
+
+			return null;
+		}
+
+		float hours = 0.0F;
+		Match hoursMatch = GeneratedRegexes.Decimal().Match(hoursNode.TextContent);
+
+		// This might fail if we have exactly 0.0 hours played, as it's not printed in that case - that's fine
+		if (hoursMatch.Success) {
+			if (!float.TryParse(hoursMatch.Value, NumberStyles.Number, CultureInfo.InvariantCulture, out hours) || (hours <= 0.0F)) {
+				Bot.ArchiLogger.LogNullError(hours);
+
+				return null;
+			}
+		}
+
+		INode? progressNode = htmlDocument.SelectSingleNode("//span[@class='progress_info_bold']");
 
 		if (progressNode == null) {
+			Bot.ArchiLogger.LogNullError(progressNode);
+
 			return null;
 		}
 
@@ -1024,19 +1050,66 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 			return null;
 		}
 
+		ushort cardsRemaining = 0;
+
 		Match match = GeneratedRegexes.Digits().Match(progress);
 
-		if (!match.Success) {
-			return 0;
+		if (match.Success) {
+			if (!ushort.TryParse(match.Value, out cardsRemaining) || (cardsRemaining == 0)) {
+				Bot.ArchiLogger.LogNullError(cardsRemaining);
+
+				return null;
+			}
 		}
 
-		if (!ushort.TryParse(match.Value, out ushort cardsRemaining) || (cardsRemaining == 0)) {
-			Bot.ArchiLogger.LogNullError(cardsRemaining);
+		byte badgeLevel = 0;
 
-			return null;
+		INode? levelNode = htmlDocument.SelectSingleNode("//div[@class='badge_info_description']/div[2]");
+
+		// There is no levelNode if we didn't craft that badge yet (level 0)
+		if (levelNode != null) {
+			string levelText = levelNode.TextContent;
+
+			if (string.IsNullOrEmpty(levelText)) {
+				Bot.ArchiLogger.LogNullError(levelText);
+
+				return null;
+			}
+
+			int levelStartIndex = levelText.IndexOf("Level ", StringComparison.OrdinalIgnoreCase);
+
+			if (levelStartIndex < 0) {
+				Bot.ArchiLogger.LogNullError(levelStartIndex);
+
+				return null;
+			}
+
+			levelStartIndex += 6;
+
+			if (levelText.Length <= levelStartIndex) {
+				Bot.ArchiLogger.LogNullError(levelStartIndex);
+
+				return null;
+			}
+
+			int levelEndIndex = levelText.IndexOf(',', levelStartIndex);
+
+			if (levelEndIndex <= levelStartIndex) {
+				Bot.ArchiLogger.LogNullError(levelEndIndex);
+
+				return null;
+			}
+
+			levelText = levelText[levelStartIndex..levelEndIndex];
+
+			if (!byte.TryParse(levelText, out badgeLevel) || badgeLevel is 0 or > 5) {
+				Bot.ArchiLogger.LogNullError(badgeLevel);
+
+				return null;
+			}
 		}
 
-		return cardsRemaining;
+		return new Game(appID, name, hours, cardsRemaining, badgeLevel);
 	}
 
 	private async Task<bool?> IsAnythingToFarm() {
@@ -1048,8 +1121,14 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		if (htmlDocument == null) {
 			Bot.ArchiLogger.LogGenericWarning(Strings.WarningCouldNotCheckBadges);
 
-			return null;
+			if (!Bot.BotConfig.EnableRiskyCardsDiscovery) {
+				return null;
+			}
+
+			return await IsAnythingToFarmRisky().ConfigureAwait(false);
 		}
+
+		ShouldSkipNewGamesIfPossible = false;
 
 		byte maxPages = 1;
 
@@ -1077,6 +1156,8 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 
 		Task mainTask = CheckPage(htmlDocument, parsedAppIDs);
 
+		bool allTasksSucceeded = true;
+
 		switch (ASF.GlobalConfig?.OptimizationMode) {
 			case GlobalConfig.EOptimizationMode.MinMemoryUsage:
 				await mainTask.ConfigureAwait(false);
@@ -1085,27 +1166,39 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 					Bot.ArchiLogger.LogGenericInfo(Strings.CheckingOtherBadgePages);
 
 					for (byte page = 2; page <= maxPages; page++) {
-						await CheckPage(page, parsedAppIDs).ConfigureAwait(false);
+						if (!await CheckPage(page, parsedAppIDs).ConfigureAwait(false)) {
+							allTasksSucceeded = false;
+						}
 					}
 				}
 
 				break;
 			default:
-				HashSet<Task> tasks = new(maxPages) { mainTask };
-
 				if (maxPages > 1) {
 					Bot.ArchiLogger.LogGenericInfo(Strings.CheckingOtherBadgePages);
+
+					HashSet<Task<bool>> tasks = new(maxPages - 1);
 
 					for (byte page = 2; page <= maxPages; page++) {
 						// ReSharper disable once InlineTemporaryVariable - we need a copy of variable being passed when in for loops, as loop will proceed before our task is launched
 						byte currentPage = page;
 						tasks.Add(CheckPage(currentPage, parsedAppIDs));
 					}
+
+					bool[] taskResults = await Task.WhenAll(tasks).ConfigureAwait(false);
+
+					if (taskResults.Any(static result => !result)) {
+						allTasksSucceeded = false;
+					}
 				}
 
-				await Task.WhenAll(tasks).ConfigureAwait(false);
+				await mainTask.ConfigureAwait(false);
 
 				break;
+		}
+
+		if (allTasksSucceeded) {
+			Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.IntersectWith(GamesToFarm.Select(static game => game.AppID));
 		}
 
 		if (GamesToFarm.Count == 0) {
@@ -1115,6 +1208,86 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 		}
 
 		ShouldResumeFarming = true;
+		await SortGamesToFarm().ConfigureAwait(false);
+
+		return true;
+	}
+
+	private async Task<bool?> IsAnythingToFarmRisky() {
+		Task<ImmutableHashSet<BoosterCreatorEntry>?> boosterCreatorEntriesTask = Bot.ArchiWebHandler.GetBoosterCreatorEntries();
+
+		ImmutableHashSet<uint>? boosterElibility = await Bot.ArchiWebHandler.GetBoosterEligibility().ConfigureAwait(false);
+
+		if (boosterElibility == null) {
+			Bot.ArchiLogger.LogGenericWarning(Strings.WarningCouldNotCheckBadges);
+
+			return null;
+		}
+
+		ImmutableHashSet<BoosterCreatorEntry>? boosterCreatorEntries = await boosterCreatorEntriesTask.ConfigureAwait(false);
+
+		if (boosterCreatorEntries == null) {
+			Bot.ArchiLogger.LogGenericWarning(Strings.WarningCouldNotCheckBadges);
+
+			return null;
+		}
+
+		GamesToFarm.Clear();
+
+		DateTime now = DateTime.UtcNow;
+
+		byte failuresInRow = 0;
+
+		// Normally we apply ordering after GamesToFarm are already found, but since this method is risky and greedy, we do as much as possible to allow user to optimize it
+		// In particular, firstly we give priority to appIDs that we already found out before, either rule them out, or prioritize
+		// Next, we apply farm priority queue right away, by both considering apps (if FarmPriorityQueueOnly) as well as giving priority to those that user specified
+		// Lastly, we forcefully apply random order to those considered the same in value, as we can't really afford massive amount of misses in a row
+#pragma warning disable CA5394 // This call isn't used in a security-sensitive manner
+		List<uint> gamesToFarm = boosterCreatorEntries.Select(static entry => entry.AppID).Where(appID => !boosterElibility.Contains(appID) && (!Bot.BotDatabase.FarmingRiskyIgnoredAppIDs.TryGetValue(appID, out DateTime ignoredUntil) || (ignoredUntil < now)) && ShouldIdle(appID)).OrderByDescending(Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Contains).ThenByDescending(Bot.IsPriorityIdling).ThenBy(static _ => Random.Shared.Next()).ToList();
+#pragma warning restore CA5394 // This call isn't used in a security-sensitive manner
+
+		Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.IntersectWith(gamesToFarm);
+
+		DateTime ignoredUntil = now.AddDays(7);
+
+		foreach (uint appID in gamesToFarm) {
+			Game? game = await GetGameCardsInfo(appID).ConfigureAwait(false);
+
+			if (game == null) {
+				if (++failuresInRow >= WebBrowser.MaxTries) {
+					// We're not going to check further
+					break;
+				}
+
+				continue;
+			}
+
+			failuresInRow = 0;
+
+			if (game.CardsRemaining == 0) {
+				Bot.BotDatabase.FarmingRiskyIgnoredAppIDs[appID] = ignoredUntil;
+				Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Remove(appID);
+
+				continue;
+			}
+
+			Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Add(appID);
+
+			GamesToFarm.Add(game);
+
+			if ((game.HoursPlayed >= Bot.BotConfig.HoursUntilCardDrops) || (GamesToFarm.Count >= ArchiHandler.MaxGamesPlayedConcurrently)) {
+				// Avoid further parsing in this risky method, we have enough for now
+				break;
+			}
+		}
+
+		if (GamesToFarm.Count == 0) {
+			ShouldResumeFarming = ShouldSkipNewGamesIfPossible = false;
+
+			return false;
+		}
+
+		ShouldResumeFarming = ShouldSkipNewGamesIfPossible = true;
 		await SortGamesToFarm().ConfigureAwait(false);
 
 		return true;
@@ -1142,19 +1315,52 @@ public sealed class CardsFarmer : IAsyncDisposable, IDisposable {
 	private async Task<bool?> ShouldFarm(Game game) {
 		ArgumentNullException.ThrowIfNull(game);
 
-		ushort? cardsRemaining = await GetCardsRemaining(game.AppID).ConfigureAwait(false);
+		Game? latestGameData = await GetGameCardsInfo(game.AppID).ConfigureAwait(false);
 
-		if (!cardsRemaining.HasValue) {
+		if (latestGameData == null) {
 			Bot.ArchiLogger.LogGenericWarning(string.Format(CultureInfo.CurrentCulture, Strings.WarningCouldNotCheckCardsStatus, game.AppID, game.GameName));
 
 			return null;
 		}
 
-		game.CardsRemaining = cardsRemaining.Value;
+		game.CardsRemaining = latestGameData.CardsRemaining;
 
 		Bot.ArchiLogger.LogGenericInfo(string.Format(CultureInfo.CurrentCulture, Strings.IdlingStatusForGame, game.AppID, game.GameName, game.CardsRemaining));
 
-		return game.CardsRemaining > 0;
+		if (game.CardsRemaining == 0) {
+			Bot.BotDatabase.FarmingRiskyPrioritizedAppIDs.Remove(game.AppID);
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private bool ShouldIdle(uint appID) {
+		if (appID == 0) {
+			throw new ArgumentOutOfRangeException(nameof(appID));
+		}
+
+		if (SalesBlacklist.Contains(appID) || (ASF.GlobalConfig?.Blacklist.Contains(appID) == true) || Bot.IsBlacklistedFromIdling(appID) || (Bot.BotConfig.FarmPriorityQueueOnly && !Bot.IsPriorityIdling(appID))) {
+			// We're configured to ignore this appID, so skip it
+			return false;
+		}
+
+		foreach (ConcurrentDictionary<uint, DateTime> sourceOfIgnoredAppIDs in SourcesOfIgnoredAppIDs) {
+			if (!sourceOfIgnoredAppIDs.TryGetValue(appID, out DateTime ignoredUntil)) {
+				continue;
+			}
+
+			if (ignoredUntil > DateTime.UtcNow) {
+				// This game is still ignored
+				return false;
+			}
+
+			// This game served its time as being ignored
+			sourceOfIgnoredAppIDs.TryRemove(appID, out _);
+		}
+
+		return true;
 	}
 
 	private async Task SortGamesToFarm() {

--- a/ArchiSteamFarm/Steam/Cards/Game.cs
+++ b/ArchiSteamFarm/Steam/Cards/Game.cs
@@ -45,7 +45,7 @@ public sealed class Game : IEquatable<Game> {
 		AppID = appID > 0 ? appID : throw new ArgumentOutOfRangeException(nameof(appID));
 		GameName = !string.IsNullOrEmpty(gameName) ? gameName : throw new ArgumentNullException(nameof(gameName));
 		HoursPlayed = hoursPlayed >= 0 ? hoursPlayed : throw new ArgumentOutOfRangeException(nameof(hoursPlayed));
-		CardsRemaining = cardsRemaining > 0 ? cardsRemaining : throw new ArgumentOutOfRangeException(nameof(cardsRemaining));
+		CardsRemaining = cardsRemaining;
 		BadgeLevel = badgeLevel;
 
 		PlayableAppID = appID;

--- a/ArchiSteamFarm/Steam/Data/BoosterCreatorEntry.cs
+++ b/ArchiSteamFarm/Steam/Data/BoosterCreatorEntry.cs
@@ -1,0 +1,34 @@
+//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// |
+// Copyright 2015-2023 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+
+namespace ArchiSteamFarm.Steam.Data;
+
+[SuppressMessage("ReSharper", "ClassCannotBeInstantiated")]
+public sealed class BoosterCreatorEntry {
+	[JsonProperty("appid", Required = Required.Always)]
+	public uint AppID { get; private set; }
+
+	[JsonConstructor]
+	private BoosterCreatorEntry() { }
+}

--- a/ArchiSteamFarm/Steam/Storage/BotConfig.cs
+++ b/ArchiSteamFarm/Steam/Storage/BotConfig.cs
@@ -63,6 +63,9 @@ public sealed class BotConfig {
 	public const bool DefaultEnabled = false;
 
 	[PublicAPI]
+	public const bool DefaultEnableRiskyCardsDiscovery = false;
+
+	[PublicAPI]
 	public const bool DefaultFarmPriorityQueueOnly = false;
 
 	[PublicAPI]
@@ -170,6 +173,9 @@ public sealed class BotConfig {
 
 	[JsonProperty(Required = Required.DisallowNull)]
 	public bool Enabled { get; private set; } = DefaultEnabled;
+
+	[JsonProperty]
+	public bool EnableRiskyCardsDiscovery { get; private set; } = DefaultEnableRiskyCardsDiscovery;
 
 	[JsonProperty(Required = Required.DisallowNull)]
 	public ImmutableList<EFarmingOrder> FarmingOrders { get; private set; } = DefaultFarmingOrders;
@@ -342,6 +348,9 @@ public sealed class BotConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeEnabled() => !Saving || (Enabled != DefaultEnabled);
+
+	[UsedImplicitly]
+	public bool ShouldSerializeEnableRiskyCardsDiscovery() => !Saving || (EnableRiskyCardsDiscovery != DefaultEnableRiskyCardsDiscovery);
 
 	[UsedImplicitly]
 	public bool ShouldSerializeFarmingOrders() => !Saving || ((FarmingOrders != DefaultFarmingOrders) && !FarmingOrders.SequenceEqual(DefaultFarmingOrders));


### PR DESCRIPTION
So, this started really badly by me finding out that in "clean" issue proposal I have over 1000 games to check, out of which not a single one has any card drops remaining. Majority of those were F2P games (where indeed, we can craft booster pack but don't have booster pack eligibility), on top of possibilities of some removed games and what else.

Therefore, this PR comes with a lot of enhancements on top of original proposal to minimize the risk of getting Steam banned and other DoS measures by doing as much 200 IQ moves as possible:

- Firstly, we can enable the additional logic by setting `EnableRiskyCardsDiscovery` bot config property to `true`. Without that, nothing changes in regards to before.
- Once enabled, we use additional fallback logic that triggers in two situations:
    - We failed loading first badge page, or
    - We failed loading at least one other badge page and successes from remaining ones resulted in zero games to farm
- Fallback logic fetches appIDs that we can craft boosters for, and appIDs that we're eligible for getting boosters from. Since first one means we own the game, and second one means we already farmed everything possible (exceptions possible), the subtraction gives us games that we can **potentially** idle for more cards.
- Just because we found a game like that, doesn't mean anything due to exceptions mentioned above. Since every single game check means firing one request, we absolutely can't afford checking e.g. 1000 games at once, as that'd guarantee a Steam ban and DoS, violating our contributing guidelines on top of being stupidly dangerous.
- This is why we're sorting this list further:
    - We apply our appID rules right away to filter out entries that make no sense to be checked, i.e. sales blacklist, global blacklist, bot blacklist, package-data temporary failures, priority queue only rules
    - Then we begin sorting remaining results. We start with cache hits (explained below), and move on to remaining rules
    - Next we order results by priority queue right away, we want to give user a way to prioritize not only final sorting but also the checking, we don't do other sorting (i.e farming orders)
    - Finally we apply randomization on top, that is, we firstly check cache hits (randomly), then prioritized appIDs (randomly) and then everything else (randomly), to ensure we have as little misses in a row as possible regardless of user settings
- Each miss we cache for up to 7 days in bot database, which is not perfect (tomorrow you can spend money in cs:go and have cards available), but it's required to not check the same 1k entries every 3 hours
- We also cache each hit for as long as we determine it's not yet fully farmed. This allows us to be smart about checking games after farming restart, since if in the previous run we already spent significant time to find those 3 out of 900 entries we were missing, we should start from checking them first.
- Since this approach is greedy and risky, we stop game checking as soon as we find, either:
    - 1 game with card drops and >= 3 hours (configurable `HoursUntilCardDrops`)
    - or 32 games with card drops total.
- This is not perfect but we can't afford to check 1k entries purely to allow user to sort them in `FarmingOrders`, we need to find a balance between performance and greedyness, this allows us to be as fast as possible in regards to performance, and it's sufficient for our needs.
- When we run out of games to farm (earlier than in normal mode, due to stopping at 32 games at the most), we do everything from beginning, starting from trying to use badge pages (again).

This overly complex approach guarantees us the following:
- As soon as user is able to use badge pages, we use them, since it's important to note that the whole logic in this PR is **risky and unwanted in long-term**, and we should do our best to minimize using it. This is why it's disabled by default and even if user enables it, we don't use it if possible.
- Once we determine that we need to use it, we try to send as little requests and overhead as possible. This is why we filter, sort, cache, prioritize and skip a lot of stuff, to ensure that people won't get banned by using this option. The worst possibility is, indeed, sending 1k requests or so to finding out what we need, but since this logic is expected to fire only for people that have excessive number of card drops, and they *should* have those games rather easily found when using this approach, I don't expect from this approach to put a lot of load on the Steam servers.
- At the same time we're still prioritizing ASF functionality and performance. We do our best to allow people to idle in Simple and Complex modes, we also respect their settings (such as idle priority queue and farming orders), even if some of them are applied only on a subset of all the results (that we had to limit due to overhead reasons).

All things considered, I'm very proud of this 200 IQ approach to solving original #3017 issue, I believe this should not cause as much harm as I initially expected when I found out that the most simple approach results in 1k requests each 3 hours, which would be dramatic in outcome.

Reviews welcome. @MavericksNightmare I'd appreciate if you could test if this addresses your original issue since I obviously don't have a test account with such situation, so a bit of this code remains untested. You can do so by picking top build from **[here](https://github.com/JustArchiNET/ArchiSteamFarm/actions/workflows/publish.yml?query=branch%3Afeature%2Frisky-cards-discovery++)** and grabbing artifact matching your ASF setup from the bottom. You need to manually put `"EnableRiskyCardsDiscovery": true` in your bot config. Let me know your thoughts, whether it works or doesn't :+1:

Closes #3017