### PR TITLE
Use generic ProducesResponseTypeAttribute instead of typeof(...)

### DIFF
--- a/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatController.cs
+++ b/ArchiSteamFarm.CustomPlugins.ExamplePlugin/CatController.cs
@@ -39,8 +39,8 @@ public sealed class CatController : ArchiController {
 	///     Fetches URL of a random cat picture.
 	/// </summary>
 	[HttpGet]
-	[ProducesResponseType(typeof(GenericResponse<Uri>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<Uri>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> CatGet() {
 		if (ASF.WebBrowser == null) {
 			throw new InvalidOperationException(nameof(ASF.WebBrowser));

--- a/ArchiSteamFarm.CustomPlugins.SignInWithSteam/SignInWithSteamController.cs
+++ b/ArchiSteamFarm.CustomPlugins.SignInWithSteam/SignInWithSteamController.cs
@@ -41,9 +41,9 @@ namespace ArchiSteamFarm.CustomPlugins.SignInWithSteam;
 [Route("/Api/Bot/{botName:required}/SignInWithSteam")]
 public sealed class SignInWithSteamController : ArchiController {
 	[HttpPost]
-	[ProducesResponseType(typeof(GenericResponse<SignInWithSteamResponse>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<SignInWithSteamResponse>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> Post(string botName, [FromBody] SignInWithSteamRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botName);
 		ArgumentNullException.ThrowIfNull(request);

--- a/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/SteamTokenDumperController.cs
+++ b/ArchiSteamFarm.OfficialPlugins.SteamTokenDumper/SteamTokenDumperController.cs
@@ -29,7 +29,7 @@ namespace ArchiSteamFarm.OfficialPlugins.SteamTokenDumper;
 [Route("Api/SteamTokenDumperPlugin")]
 public sealed class SteamTokenDumperController : ArchiController {
 	[HttpGet(nameof(GlobalConfigExtension))]
-	[ProducesResponseType(typeof(GlobalConfigExtension), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GlobalConfigExtension>((int) HttpStatusCode.OK)]
 	[SwaggerOperation(Tags = new[] { nameof(GlobalConfigExtension) })]
 	public ActionResult<GlobalConfigExtension> Get() => Ok(new GlobalConfigExtension());
 }

--- a/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/ASFController.cs
@@ -43,8 +43,8 @@ public sealed class ASFController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("Encrypt")]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> ASFEncryptPost([FromBody] ASFEncryptRequest request) {
 		ArgumentNullException.ThrowIfNull(request);
 
@@ -61,7 +61,7 @@ public sealed class ASFController : ArchiController {
 	///     Fetches common info related to ASF as a whole.
 	/// </summary>
 	[HttpGet]
-	[ProducesResponseType(typeof(GenericResponse<ASFResponse>), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse<ASFResponse>>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse<ASFResponse>> ASFGet() {
 		if (ASF.GlobalConfig == null) {
 			throw new InvalidOperationException(nameof(ASF.GlobalConfig));
@@ -79,8 +79,8 @@ public sealed class ASFController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("Hash")]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> ASFHashPost([FromBody] ASFHashRequest request) {
 		ArgumentNullException.ThrowIfNull(request);
 
@@ -98,8 +98,8 @@ public sealed class ASFController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> ASFPost([FromBody] ASFRequest request) {
 		ArgumentNullException.ThrowIfNull(request);
 
@@ -150,7 +150,7 @@ public sealed class ASFController : ArchiController {
 	///     Makes ASF shutdown itself.
 	/// </summary>
 	[HttpPost("Exit")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> ExitPost() {
 		(bool success, string message) = Actions.Exit();
 
@@ -161,7 +161,7 @@ public sealed class ASFController : ArchiController {
 	///     Makes ASF restart itself.
 	/// </summary>
 	[HttpPost("Restart")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> RestartPost() {
 		(bool success, string message) = Actions.Restart();
 
@@ -172,7 +172,7 @@ public sealed class ASFController : ArchiController {
 	///     Makes ASF update itself.
 	/// </summary>
 	[HttpPost("Update")]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
 	public async Task<ActionResult<GenericResponse<string>>> UpdatePost([FromBody] UpdateRequest request) {
 		ArgumentNullException.ThrowIfNull(request);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/BotController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/BotController.cs
@@ -44,8 +44,8 @@ public sealed class BotController : ArchiController {
 	///     Deletes all files related to given bots.
 	/// </summary>
 	[HttpDelete("{botNames:required}")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> BotDelete(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -64,8 +64,8 @@ public sealed class BotController : ArchiController {
 	///     Fetches common info related to given bots.
 	/// </summary>
 	[HttpGet("{botNames:required}")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, Bot>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, Bot>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> BotGet(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -83,8 +83,8 @@ public sealed class BotController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("{botNames:required}")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, bool>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, bool>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> BotPost(string botNames, [FromBody] BotRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -155,8 +155,8 @@ public sealed class BotController : ArchiController {
 	///     Removes BGR output files of given bots.
 	/// </summary>
 	[HttpDelete("{botNames:required}/GamesToRedeemInBackground")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> GamesToRedeemInBackgroundDelete(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -175,8 +175,8 @@ public sealed class BotController : ArchiController {
 	///     Fetches BGR output files of given bots.
 	/// </summary>
 	[HttpGet("{botNames:required}/GamesToRedeemInBackground")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GamesToRedeemInBackgroundResponse>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GamesToRedeemInBackgroundResponse>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> GamesToRedeemInBackgroundGet(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -203,8 +203,8 @@ public sealed class BotController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("{botNames:required}/GamesToRedeemInBackground")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, IOrderedDictionary>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, IOrderedDictionary>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> GamesToRedeemInBackgroundPost(string botNames, [FromBody] BotGamesToRedeemInBackgroundRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -241,8 +241,8 @@ public sealed class BotController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("{botNames:required}/Input")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> InputPost(string botNames, [FromBody] BotInputRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -267,8 +267,8 @@ public sealed class BotController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("{botNames:required}/Pause")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> PausePost(string botNames, [FromBody] BotPauseRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -293,8 +293,8 @@ public sealed class BotController : ArchiController {
 	/// </remarks>
 	[Consumes("application/json")]
 	[HttpPost("{botNames:required}/Redeem")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, IReadOnlyDictionary<string, CStore_RegisterCDKey_Response>>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, IReadOnlyDictionary<string, CStore_RegisterCDKey_Response>>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> RedeemPost(string botNames, [FromBody] BotRedeemRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -332,8 +332,8 @@ public sealed class BotController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("{botName:required}/Rename")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> RenamePost(string botName, [FromBody] BotRenameRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botName);
 		ArgumentNullException.ThrowIfNull(request);
@@ -359,8 +359,8 @@ public sealed class BotController : ArchiController {
 	///     Resumes given bots.
 	/// </summary>
 	[HttpPost("{botNames:required}/Resume")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> ResumePost(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -379,8 +379,8 @@ public sealed class BotController : ArchiController {
 	///     Starts given bots.
 	/// </summary>
 	[HttpPost("{botNames:required}/Start")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> StartPost(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -399,8 +399,8 @@ public sealed class BotController : ArchiController {
 	///     Stops given bots.
 	/// </summary>
 	[HttpPost("{botNames:required}/Stop")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> StopPost(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/CommandController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/CommandController.cs
@@ -44,8 +44,8 @@ public sealed class CommandController : ArchiController {
 	/// </remarks>
 	[Consumes("application/json")]
 	[HttpPost]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> CommandPost([FromBody] CommandRequest request) {
 		ArgumentNullException.ThrowIfNull(request);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/GitHubController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/GitHubController.cs
@@ -42,8 +42,8 @@ public sealed class GitHubController : ArchiController {
 	///     This is internal API being utilizied by our ASF-ui IPC frontend. You should not depend on existence of any /Api/WWW endpoints as they can disappear and change anytime.
 	/// </remarks>
 	[HttpGet("Release")]
-	[ProducesResponseType(typeof(GenericResponse<GitHubReleaseResponse>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<GitHubReleaseResponse>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> GitHubReleaseGet() {
 		CancellationToken cancellationToken = HttpContext.RequestAborted;
 
@@ -59,9 +59,9 @@ public sealed class GitHubController : ArchiController {
 	///     This is internal API being utilizied by our ASF-ui IPC frontend. You should not depend on existence of any /Api/WWW endpoints as they can disappear and change anytime.
 	/// </remarks>
 	[HttpGet("Release/{version:required}")]
-	[ProducesResponseType(typeof(GenericResponse<GitHubReleaseResponse>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<GitHubReleaseResponse>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> GitHubReleaseGet(string version) {
 		ArgumentException.ThrowIfNullOrEmpty(version);
 
@@ -94,9 +94,9 @@ public sealed class GitHubController : ArchiController {
 	///     This is internal API being utilizied by our ASF-ui IPC frontend. You should not depend on existence of any /Api/WWW endpoints as they can disappear and change anytime.
 	/// </remarks>
 	[HttpGet("Wiki/History/{page:required}")]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> GitHubWikiHistoryGet(string page) {
 		ArgumentException.ThrowIfNullOrEmpty(page);
 
@@ -115,9 +115,9 @@ public sealed class GitHubController : ArchiController {
 	///     Specifying revision is optional - when not specified, will fetch latest available. If specified revision is invalid, GitHub will automatically fetch the latest revision as well.
 	/// </remarks>
 	[HttpGet("Wiki/Page/{page:required}")]
-	[ProducesResponseType(typeof(GenericResponse<string>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<string>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> GitHubWikiPageGet(string page, [FromQuery] string? revision = null) {
 		ArgumentException.ThrowIfNullOrEmpty(page);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/IPCBansController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/IPCBansController.cs
@@ -37,7 +37,7 @@ public sealed class IPCBansController : ArchiController {
 	///     Clears the list of all IP addresses currently blocked by ASFs IPC module
 	/// </summary>
 	[HttpDelete]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> Delete() {
 		ApiAuthenticationMiddleware.ClearFailedAuthorizations();
 
@@ -48,8 +48,8 @@ public sealed class IPCBansController : ArchiController {
 	///     Removes an IP address from the list of addresses currently blocked by ASFs IPC module
 	/// </summary>
 	[HttpDelete("{ipAddress:required}")]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> DeleteSpecific(string ipAddress) {
 		ArgumentException.ThrowIfNullOrEmpty(ipAddress);
 
@@ -70,6 +70,6 @@ public sealed class IPCBansController : ArchiController {
 	///     Gets all IP addresses currently blocked by ASFs IPC module
 	/// </summary>
 	[HttpGet]
-	[ProducesResponseType(typeof(GenericResponse<ISet<string>>), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse<ISet<string>>>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse<ISet<string>>> Get() => Ok(new GenericResponse<ISet<string>>(ApiAuthenticationMiddleware.GetCurrentlyBannedIPs().Select(static ip => ip.ToString()).ToHashSet()));
 }

--- a/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
@@ -50,9 +50,9 @@ public sealed class NLogController : ArchiController {
 	/// <param name="count">Maximum amount of lines from the log file returned. The respone naturally might have less amount than specified, if you've read whole file already.</param>
 	/// <param name="lastAt">Ending index, used for pagination. Omit it for the first request, then initialize to TotalLines returned, and on every following request subtract count that you've used in the previous request from it until you hit 0 or less, which means you've read whole file already.</param>
 	[HttpGet("File")]
-	[ProducesResponseType(typeof(GenericResponse<GenericResponse<LogResponse>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.ServiceUnavailable)]
+	[ProducesResponseType<GenericResponse<GenericResponse<LogResponse>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.ServiceUnavailable)]
 	public async Task<ActionResult<GenericResponse>> FileGet(int count = 100, int lastAt = 0) {
 		if (count <= 0) {
 			return BadRequest(new GenericResponse(false, string.Format(CultureInfo.CurrentCulture, Strings.ErrorIsInvalid, nameof(count))));
@@ -88,8 +88,8 @@ public sealed class NLogController : ArchiController {
 	///     This API endpoint requires a websocket connection.
 	/// </remarks>
 	[HttpGet]
-	[ProducesResponseType(typeof(IEnumerable<GenericResponse<string>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<IEnumerable<GenericResponse<string>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult> Get(CancellationToken cancellationToken) {
 		if (HttpContext == null) {
 			throw new InvalidOperationException(nameof(HttpContext));

--- a/ArchiSteamFarm/IPC/Controllers/Api/PluginsController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/PluginsController.cs
@@ -32,7 +32,7 @@ namespace ArchiSteamFarm.IPC.Controllers.Api;
 [Route("Api/Plugins")]
 public sealed class PluginsController : ArchiController {
 	[HttpGet]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyCollection<IPlugin>>), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse<IReadOnlyCollection<IPlugin>>>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse<IReadOnlyCollection<IPlugin>>> PluginsGet() {
 		IReadOnlyCollection<IPlugin> activePlugins = PluginsCore.ActivePlugins ?? (IReadOnlyCollection<IPlugin>) Array.Empty<IPlugin>();
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/StorageController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/StorageController.cs
@@ -34,7 +34,7 @@ public sealed class StorageController : ArchiController {
 	///     Deletes entry under specified key from ASF's persistent KeyValue JSON storage.
 	/// </summary>
 	[HttpDelete]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> StorageDelete(string key) {
 		ArgumentException.ThrowIfNullOrEmpty(key);
 
@@ -51,7 +51,7 @@ public sealed class StorageController : ArchiController {
 	///     Loads entry under specified key from ASF's persistent KeyValue JSON storage.
 	/// </summary>
 	[HttpGet]
-	[ProducesResponseType(typeof(GenericResponse<JToken>), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse<JToken>>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> StorageGet(string key) {
 		ArgumentException.ThrowIfNullOrEmpty(key);
 
@@ -69,7 +69,7 @@ public sealed class StorageController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.OK)]
 	public ActionResult<GenericResponse> StoragePost(string key, [FromBody] JToken value) {
 		ArgumentException.ThrowIfNullOrEmpty(key);
 		ArgumentNullException.ThrowIfNull(value);

--- a/ArchiSteamFarm/IPC/Controllers/Api/StructureController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/StructureController.cs
@@ -37,8 +37,8 @@ public sealed class StructureController : ArchiController {
 	///     Structure is defined as a representation of given object in its default state.
 	/// </remarks>
 	[HttpGet("{structure:required}")]
-	[ProducesResponseType(typeof(GenericResponse<object>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<object>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> StructureGet(string structure) {
 		ArgumentException.ThrowIfNullOrEmpty(structure);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/TwoFactorAuthenticationController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/TwoFactorAuthenticationController.cs
@@ -42,8 +42,8 @@ public sealed class TwoFactorAuthenticationController : ArchiController {
 	///     Fetches pending 2FA confirmations of given bots, requires ASF 2FA module to be active on them.
 	/// </summary>
 	[HttpGet("Confirmations")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GenericResponse<IReadOnlyCollection<Confirmation>>>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GenericResponse<IReadOnlyCollection<Confirmation>>>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> ConfirmationsGet(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -70,8 +70,8 @@ public sealed class TwoFactorAuthenticationController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost("Confirmations")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GenericResponse<IReadOnlyCollection<Confirmation>>>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GenericResponse<IReadOnlyCollection<Confirmation>>>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> ConfirmationsPost(string botNames, [FromBody] TwoFactorAuthenticationConfirmationsRequest request) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(request);
@@ -102,8 +102,8 @@ public sealed class TwoFactorAuthenticationController : ArchiController {
 	///     Deletes the MobileAuthenticator of given bots if an ASF 2FA module is active on them.
 	/// </summary>
 	[HttpDelete]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GenericResponse<string>>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GenericResponse<string>>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> Delete(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 
@@ -130,8 +130,8 @@ public sealed class TwoFactorAuthenticationController : ArchiController {
 	/// </summary>
 	[Consumes("application/json")]
 	[HttpPost]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GenericResponse>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GenericResponse>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> Post(string botNames, [FromBody] MobileAuthenticator authenticator) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 		ArgumentNullException.ThrowIfNull(authenticator);
@@ -158,8 +158,8 @@ public sealed class TwoFactorAuthenticationController : ArchiController {
 	///     Fetches 2FA tokens of given bots, requires ASF 2FA module to be active on them.
 	/// </summary>
 	[HttpGet("Token")]
-	[ProducesResponseType(typeof(GenericResponse<IReadOnlyDictionary<string, GenericResponse<string>>>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<IReadOnlyDictionary<string, GenericResponse<string>>>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult<GenericResponse>> TokenGet(string botNames) {
 		ArgumentException.ThrowIfNullOrEmpty(botNames);
 

--- a/ArchiSteamFarm/IPC/Controllers/Api/TypeController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/TypeController.cs
@@ -42,8 +42,8 @@ public sealed class TypeController : ArchiController {
 	///     Type info is defined as a representation of given object with its fields and properties being assigned to a string value that defines their type.
 	/// </remarks>
 	[HttpGet("{type:required}")]
-	[ProducesResponseType(typeof(GenericResponse<TypeResponse>), (int) HttpStatusCode.OK)]
-	[ProducesResponseType(typeof(GenericResponse), (int) HttpStatusCode.BadRequest)]
+	[ProducesResponseType<GenericResponse<TypeResponse>>((int) HttpStatusCode.OK)]
+	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public ActionResult<GenericResponse> TypeGet(string type) {
 		ArgumentException.ThrowIfNullOrEmpty(type);
 


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

The code now uses the generic version of `ProducesResponseType` on the controller methods in the IPC server to get rid of the overly explicit `typeof(...)` we've previously used.

### New functionality

None

### Changed functionality

None

### Removed functionality

None

## Additional info

Thank you for considering the inclusion of this merge request.
