### PR TITLE
Flash console window on input request on Windows

### DIFF
--- a/ArchiSteamFarm/Core/NativeMethods.cs
+++ b/ArchiSteamFarm/Core/NativeMethods.cs
@@ -1,18 +1,20 @@
+// ----------------------------------------------------------------------------------------------
 //     _                _      _  ____   _                           _____
 //    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
 //   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
 //  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
 // /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
-// |
+// ----------------------------------------------------------------------------------------------
+//
 // Copyright 2015-2024 Łukasz "JustArchi" Domeradzki
 // Contact: JustArchi@JustArchi.net
-// |
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// |
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// |
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +28,12 @@ using System.Runtime.Versioning;
 namespace ArchiSteamFarm.Core;
 
 internal static partial class NativeMethods {
+	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+	[SupportedOSPlatform("Windows")]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	[LibraryImport("user32.dll")]
+	internal static partial void FlashWindowEx(ref FlashWInfo pwfi);
+
 	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 	[SupportedOSPlatform("Windows")]
 	[return: MarshalAs(UnmanagedType.Bool)]
@@ -78,6 +86,16 @@ internal static partial class NativeMethods {
 	}
 
 	[SupportedOSPlatform("Windows")]
+	[Flags]
+	internal enum EFlashFlags : uint {
+		Stop = 0,
+		Caption = 1,
+		Tray = 2,
+		All = Caption | Tray,
+		Timer = 4
+	}
+
+	[SupportedOSPlatform("Windows")]
 	internal enum EShowWindow : uint {
 		Minimize = 6
 	}
@@ -85,5 +103,14 @@ internal static partial class NativeMethods {
 	[SupportedOSPlatform("Windows")]
 	internal enum EStandardHandle {
 		Input = -10
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	internal struct FlashWInfo {
+		public uint cbSize;
+		public EFlashFlags dwFlags;
+		public int dwTimeout;
+		public nint hWnd;
+		public uint uCount;
 	}
 }

--- a/ArchiSteamFarm/Core/NativeMethods.cs
+++ b/ArchiSteamFarm/Core/NativeMethods.cs
@@ -41,11 +41,6 @@ internal static partial class NativeMethods {
 	internal static partial bool GetConsoleMode(nint hConsoleHandle, out EConsoleMode lpMode);
 
 	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-	[SupportedOSPlatform("Windows")]
-	[LibraryImport("kernel32.dll")]
-	internal static partial nint GetConsoleWindow();
-
-	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 	[SupportedOSPlatform("FreeBSD")]
 	[SupportedOSPlatform("Linux")]
 	[SupportedOSPlatform("MacOS")]

--- a/ArchiSteamFarm/Core/NativeMethods.cs
+++ b/ArchiSteamFarm/Core/NativeMethods.cs
@@ -112,10 +112,10 @@ internal static partial class NativeMethods {
 
 	[StructLayout(LayoutKind.Sequential)]
 	internal struct FlashWindowInfo {
-		public uint cbSize;
-		public EFlashFlags dwFlags;
-		public uint dwTimeout;
-		public nint hWnd;
-		public uint uCount;
+		public uint StructSize;
+		public nint WindowHandle;
+		public EFlashFlags Flags;
+		public uint Count;
+		public uint TimeoutBetweenFlashes;
 	}
 }

--- a/ArchiSteamFarm/Core/NativeMethods.cs
+++ b/ArchiSteamFarm/Core/NativeMethods.cs
@@ -32,13 +32,18 @@ internal static partial class NativeMethods {
 	[SupportedOSPlatform("Windows")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	[LibraryImport("user32.dll")]
-	internal static partial void FlashWindowEx(ref FlashWInfo pwfi);
+	internal static partial void FlashWindowEx(ref FlashWindowInfo pwfi);
 
 	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 	[SupportedOSPlatform("Windows")]
 	[return: MarshalAs(UnmanagedType.Bool)]
 	[LibraryImport("kernel32.dll")]
 	internal static partial bool GetConsoleMode(nint hConsoleHandle, out EConsoleMode lpMode);
+
+	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+	[SupportedOSPlatform("Windows")]
+	[LibraryImport("kernel32.dll")]
+	internal static partial nint GetConsoleWindow();
 
 	[DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
 	[SupportedOSPlatform("FreeBSD")]
@@ -106,10 +111,10 @@ internal static partial class NativeMethods {
 	}
 
 	[StructLayout(LayoutKind.Sequential)]
-	internal struct FlashWInfo {
+	internal struct FlashWindowInfo {
 		public uint cbSize;
 		public EFlashFlags dwFlags;
-		public int dwTimeout;
+		public uint dwTimeout;
 		public nint hWnd;
 		public uint uCount;
 	}

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -275,7 +275,7 @@ internal static class OS {
 
 	private static void MinimizeConsoleWindow() {
 		// Will work if the terminal supports XTWINOPS sequences, reference: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-		Console.Write("\x1b[2;2;2t\r");
+		Console.Write('\x1b' + @"[2;2;2t\r");
 
 		// Fallback if we're using conhost on Windows
 		if (OperatingSystem.IsWindows()) {

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -26,6 +26,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -235,13 +236,11 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
-		using Process process = Process.GetCurrentProcess();
-
-		NativeMethods.FlashWInfo flashInfo = new() {
-			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWInfo>(),
+		NativeMethods.FlashWindowInfo flashInfo = new() {
+			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWindowInfo>(),
 			dwFlags = NativeMethods.EFlashFlags.All | NativeMethods.EFlashFlags.Timer,
 			dwTimeout = 0,
-			hWnd = process.MainWindowHandle,
+			hWnd = GetConsoleHandleForFlashing(),
 			uCount = uint.MaxValue
 		};
 
@@ -254,15 +253,22 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
-		using Process process = Process.GetCurrentProcess();
-
-		NativeMethods.FlashWInfo flashInfo = new() {
-			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWInfo>(),
+		NativeMethods.FlashWindowInfo flashInfo = new() {
+			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWindowInfo>(),
 			dwFlags = NativeMethods.EFlashFlags.Stop,
-			hWnd = process.MainWindowHandle
+			hWnd = GetConsoleHandleForFlashing()
 		};
 
 		NativeMethods.FlashWindowEx(ref flashInfo);
+	}
+
+	[SupportedOSPlatform("Windows")]
+	private static nint GetConsoleHandleForFlashing() {
+		Process? winTermProcess = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
+
+		using (winTermProcess) {
+			return winTermProcess?.MainWindowHandle ?? NativeMethods.GetConsoleWindow();
+		}
 	}
 
 	[SupportedOSPlatform("Windows")]
@@ -309,8 +315,6 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
-		using Process process = Process.GetCurrentProcess();
-
-		NativeMethods.ShowWindow(process.MainWindowHandle, NativeMethods.EShowWindow.Minimize);
+		NativeMethods.ShowWindow(NativeMethods.GetConsoleWindow(), NativeMethods.EShowWindow.Minimize);
 	}
 }

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -1,18 +1,20 @@
+// ----------------------------------------------------------------------------------------------
 //     _                _      _  ____   _                           _____
 //    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
 //   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
 //  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
 // /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
-// |
+// ----------------------------------------------------------------------------------------------
+//
 // Copyright 2015-2024 Łukasz "JustArchi" Domeradzki
 // Contact: JustArchi@JustArchi.net
-// |
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// |
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// |
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -225,6 +227,42 @@ internal static class OS {
 		ASF.ArchiLogger.LogGenericError(string.Format(CultureInfo.CurrentCulture, Strings.WarningUnknownValuePleaseReport, nameof(SharedInfo.BuildInfo.Variant), SharedInfo.BuildInfo.Variant));
 
 		return false;
+	}
+
+	[SupportedOSPlatform("Windows")]
+	internal static void WindowsStartFlashingConsoleWindow() {
+		if (!OperatingSystem.IsWindows()) {
+			throw new PlatformNotSupportedException();
+		}
+
+		using Process process = Process.GetCurrentProcess();
+
+		NativeMethods.FlashWInfo flashInfo = new() {
+			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWInfo>(),
+			dwFlags = NativeMethods.EFlashFlags.All | NativeMethods.EFlashFlags.Timer,
+			dwTimeout = 0,
+			hWnd = process.MainWindowHandle,
+			uCount = uint.MaxValue
+		};
+
+		NativeMethods.FlashWindowEx(ref flashInfo);
+	}
+
+	[SupportedOSPlatform("Windows")]
+	internal static void WindowsStopFlashingConsoleWindow() {
+		if (!OperatingSystem.IsWindows()) {
+			throw new PlatformNotSupportedException();
+		}
+
+		using Process process = Process.GetCurrentProcess();
+
+		NativeMethods.FlashWInfo flashInfo = new() {
+			cbSize = (uint) Marshal.SizeOf<NativeMethods.FlashWInfo>(),
+			dwFlags = NativeMethods.EFlashFlags.Stop,
+			hWnd = process.MainWindowHandle
+		};
+
+		NativeMethods.FlashWindowEx(ref flashInfo);
 	}
 
 	[SupportedOSPlatform("Windows")]

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -236,10 +236,16 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
+		nint handle = WindowsGetConsoleHandleForFlashing();
+
+		if (handle == nint.Zero) {
+			return;
+		}
+
 		NativeMethods.FlashWindowInfo flashInfo = new() {
 			StructSize = (uint) Marshal.SizeOf<NativeMethods.FlashWindowInfo>(),
 			Flags = NativeMethods.EFlashFlags.All | NativeMethods.EFlashFlags.Timer,
-			WindowHandle = WindowsGetConsoleHandleForFlashing(),
+			WindowHandle = handle,
 			Count = uint.MaxValue
 		};
 
@@ -252,10 +258,16 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
+		nint handle = WindowsGetConsoleHandleForFlashing();
+
+		if (handle == nint.Zero) {
+			return;
+		}
+
 		NativeMethods.FlashWindowInfo flashInfo = new() {
 			StructSize = (uint) Marshal.SizeOf<NativeMethods.FlashWindowInfo>(),
 			Flags = NativeMethods.EFlashFlags.Stop,
-			WindowHandle = WindowsGetConsoleHandleForFlashing()
+			WindowHandle = handle
 		};
 
 		NativeMethods.FlashWindowEx(ref flashInfo);
@@ -305,12 +317,17 @@ internal static class OS {
 		}
 
 		using Process process = Process.GetCurrentProcess();
-		Process? winTermProcess = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
 
-		if (winTermProcess != null) {
-			using (winTermProcess) {
-				return winTermProcess.MainWindowHandle;
+		if (process.MainWindowHandle == IntPtr.Zero) {
+			Process? winTermProcess = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
+
+			if (winTermProcess != null) {
+				using (winTermProcess) {
+					return winTermProcess.MainWindowHandle;
+				}
 			}
+
+			return nint.Zero;
 		}
 
 		return process.MainWindowHandle;

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -26,7 +26,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
@@ -236,7 +235,8 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
-		nint handle = WindowsGetConsoleHandleForFlashing();
+		using Process currentProcess = Process.GetCurrentProcess();
+		nint handle = currentProcess.MainWindowHandle;
 
 		if (handle == nint.Zero) {
 			return;
@@ -258,7 +258,8 @@ internal static class OS {
 			throw new PlatformNotSupportedException();
 		}
 
-		nint handle = WindowsGetConsoleHandleForFlashing();
+		using Process currentProcess = Process.GetCurrentProcess();
+		nint handle = currentProcess.MainWindowHandle;
 
 		if (handle == nint.Zero) {
 			return;
@@ -308,29 +309,6 @@ internal static class OS {
 		if (!NativeMethods.SetConsoleMode(consoleHandle, consoleMode)) {
 			ASF.ArchiLogger.LogGenericError(Strings.WarningFailed);
 		}
-	}
-
-	[SupportedOSPlatform("Windows")]
-	private static nint WindowsGetConsoleHandleForFlashing() {
-		if (!OperatingSystem.IsWindows()) {
-			throw new PlatformNotSupportedException();
-		}
-
-		using Process process = Process.GetCurrentProcess();
-
-		if (process.MainWindowHandle == IntPtr.Zero) {
-			Process? winTermProcess = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
-
-			if (winTermProcess != null) {
-				using (winTermProcess) {
-					return winTermProcess.MainWindowHandle;
-				}
-			}
-
-			return nint.Zero;
-		}
-
-		return process.MainWindowHandle;
 	}
 
 	[SupportedOSPlatform("Windows")]

--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -1,18 +1,20 @@
+// ----------------------------------------------------------------------------------------------
 //     _                _      _  ____   _                           _____
 //    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
 //   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
 //  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
 // /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
-// |
+// ----------------------------------------------------------------------------------------------
+//
 // Copyright 2015-2024 Łukasz "JustArchi" Domeradzki
 // Contact: JustArchi@JustArchi.net
-// |
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// |
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// |
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -292,9 +294,17 @@ internal static class Logging {
 
 			Utilities.InBackground(() => BeepUntilCanceled(token));
 
+			if (OperatingSystem.IsWindows()) {
+				OS.WindowsStartFlashingConsoleWindow();
+			}
+
 			return Console.ReadLine();
 		} finally {
 			cts.Cancel();
+
+			if (OperatingSystem.IsWindows()) {
+				OS.WindowsStopFlashingConsoleWindow();
+			}
 		}
 	}
 
@@ -305,6 +315,10 @@ internal static class Logging {
 			CancellationToken token = cts.Token;
 
 			Utilities.InBackground(() => BeepUntilCanceled(token));
+
+			if (OperatingSystem.IsWindows()) {
+				OS.WindowsStartFlashingConsoleWindow();
+			}
 
 			StringBuilder result = new();
 
@@ -341,6 +355,10 @@ internal static class Logging {
 			}
 		} finally {
 			cts.Cancel();
+
+			if (OperatingSystem.IsWindows()) {
+				OS.WindowsStopFlashingConsoleWindow();
+			}
 		}
 	}
 

--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -282,7 +282,7 @@ internal static class Logging {
 				return;
 			}
 
-			Console.Beep();
+			Console.Write((char) 7);
 		}
 	}
 

--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -282,7 +282,7 @@ internal static class Logging {
 				return;
 			}
 
-			Console.Write((char) 7);
+			Console.Write('\a');
 		}
 	}
 


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

Adds flashing console window on Windows when ASF requests the user input.

### Changed functionality

None.

### Removed functionality

None.

## Additional info

Resolves #2998.
