### PR TITLE
Fix GetTradeOffer exception

### DIFF
--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -501,7 +501,7 @@ public sealed class ArchiWebHandler : IDisposable {
 			trades = trades.Concat(response.TradeOffersSent);
 		}
 
-		Dictionary<(uint AppID, ulong ClassID, ulong InstanceID), InventoryDescription> descriptions = response.Descriptions.ToDictionary(static description => (description.AppID, description.ClassID, description.InstanceID), static description => description);
+		Dictionary<(uint AppID, ulong ClassID, ulong InstanceID), InventoryDescription> descriptions = response.Descriptions.GroupBy(static description => (description.AppID, description.ClassID, description.InstanceID)).ToDictionary(static group => group.Key, static group => group.First());
 
 		HashSet<TradeOffer> result = [];
 


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

<!-- Please describe below, what new functionality was added. -->

None

### Changed functionality

<!-- Please describe below, what old functionality was changed. -->

None

### Removed functionality

<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

None

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->

Fixes an exception I've been seeing in 6.0.1.3 and 6.0.1.4 when trading between bots.  On seemingly random trades, the same item will appear multiple times in the trade description, producing this error and blocking the trades from being accepted by ASF:

```
2024-03-18 20:15:46|ArchiSteamFarm-3412129|FATAL|ASF|OnUnobservedTaskException() System.ArgumentException: An item with the same key has already been added. Key: (753, 2320557464, 0)
   at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
   at System.Collections.Generic.Dictionary`2.Add(TKey key, TValue value)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector)
   at ArchiSteamFarm.Steam.Integration.ArchiWebHandler.GetTradeOffers(Nullable`1 activeOnly, Nullable`1 receivedOffers, Nullable`1 sentOffers, Nullable`1 withDescriptions) in /ArchiSteamFarm/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs:line 505
   at ArchiSteamFarm.Steam.Exchange.Trading.ParseActiveTrades() in /ArchiSteamFarm/ArchiSteamFarm/Steam/Exchange/Trading.cs:line 263
   at ArchiSteamFarm.Steam.Exchange.Trading.OnNewTrade() in /ArchiSteamFarm/ArchiSteamFarm/Steam/Exchange/Trading.cs:line 231
```

If you'd like to see the response from https://api.steampowered.com/IEconService/GetTradeOffers that produces this error I can provide it.