### PR TITLE
Add family join confirmation type

### DIFF
--- a/ArchiSteamFarm/Steam/Data/Confirmation.cs
+++ b/ArchiSteamFarm/Steam/Data/Confirmation.cs
@@ -36,6 +36,11 @@ public sealed class Confirmation {
 	public EConfirmationType ConfirmationType { get; private init; }
 
 	[JsonInclude]
+	[JsonPropertyName("type_text")]
+	[JsonRequired]
+	public string ConfirmationTypeText { get; private init; } = null!;
+
+	[JsonInclude]
 	[JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
 	[JsonPropertyName("creator_id")]
 	[JsonRequired]
@@ -67,6 +72,7 @@ public sealed class Confirmation {
 		Market,
 		PhoneNumberChange = 5,
 		AccountRecovery = 6,
-		ApiKeyRegistration = 9
+		ApiKeyRegistration = 9,
+		FamilyJoin = 11
 	}
 }

--- a/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
+++ b/ArchiSteamFarm/Steam/Security/MobileAuthenticator.cs
@@ -183,7 +183,7 @@ public sealed class MobileAuthenticator : IDisposable {
 		}
 
 		foreach (Confirmation? confirmation in response.Confirmations.Where(static confirmation => (confirmation.ConfirmationType == Confirmation.EConfirmationType.Unknown) || !Enum.IsDefined(confirmation.ConfirmationType))) {
-			Bot.ArchiLogger.LogGenericError(string.Format(CultureInfo.CurrentCulture, Strings.WarningUnknownValuePleaseReport, nameof(confirmation.ConfirmationType), confirmation.ConfirmationType));
+			Bot.ArchiLogger.LogGenericError(string.Format(CultureInfo.CurrentCulture, Strings.WarningUnknownValuePleaseReport, nameof(confirmation.ConfirmationType), $"{confirmation.ConfirmationType} ({confirmation.ConfirmationTypeText})"));
 		}
 
 		return response.Confirmations;


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

Add support for family join confirmation type, also log text type when encountering a confirmation with the unknown type.

### Changed functionality

None

### Removed functionality

None

## Additional info

Logging text type is future-proofing so the log message itself would be enough to add a new type.
