### PR TITLE
Closes #3156

### DIFF
--- a/ArchiSteamFarm/Core/ASF.cs
+++ b/ArchiSteamFarm/Core/ASF.cs
@@ -781,36 +781,8 @@ public static class ASF {
 		await UpdateSemaphore.WaitAsync().ConfigureAwait(false);
 
 		try {
-			try {
-				// If directories from previous update exist, it's a good idea to purge them now
-				foreach (string directory in Directory.EnumerateDirectories(SharedInfo.HomeDirectory, $"{SharedInfo.UpdateDirectoryNewPrefix}*")) {
-					ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					Directory.Delete(directory, true);
-
-					ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-
-				foreach (string directory in Directory.EnumerateDirectories(SharedInfo.HomeDirectory, $"{SharedInfo.UpdateDirectoryOldPrefix}*")) {
-					ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					await Utilities.DeletePotentiallyUsedDirectory(directory).ConfigureAwait(false);
-
-					ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-
-				string backupDirectory = Path.Combine(SharedInfo.HomeDirectory, SharedInfo.UpdateDirectoryOld);
-
-				if (Directory.Exists(backupDirectory)) {
-					ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					await Utilities.DeletePotentiallyUsedDirectory(backupDirectory).ConfigureAwait(false);
-
-					ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-			} catch (Exception e) {
-				ArchiLogger.LogGenericException(e);
-
+			// If directories from previous update exist, it's a good idea to purge them now
+			if (!await Utilities.UpdateCleanup(SharedInfo.HomeDirectory).ConfigureAwait(false)) {
 				return (false, null);
 			}
 

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -387,8 +387,6 @@ public static class Utilities {
 
 		foreach (ZipArchiveEntry zipFile in zipArchive.Entries) {
 			switch (zipFile.Name) {
-				case null:
-				case "":
 				case ".gitkeep":
 					// We're not interested in extracting placeholder files
 					continue;

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -329,36 +329,48 @@ public static class Utilities {
 	internal static async Task<bool> UpdateCleanup(string targetDirectory) {
 		ArgumentException.ThrowIfNullOrEmpty(targetDirectory);
 
+		bool updateCleanup = false;
+
 		try {
 			foreach (string directory in Directory.EnumerateDirectories(targetDirectory, $"{SharedInfo.UpdateDirectoryNewPrefix}*")) {
-				ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				if (!updateCleanup) {
+					updateCleanup = true;
+
+					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				}
 
 				Directory.Delete(directory, true);
-
-				ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 			}
 
 			foreach (string directory in Directory.EnumerateDirectories(targetDirectory, $"{SharedInfo.UpdateDirectoryOldPrefix}*")) {
-				ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				if (!updateCleanup) {
+					updateCleanup = true;
+
+					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				}
 
 				await DeletePotentiallyUsedDirectory(directory).ConfigureAwait(false);
-
-				ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 			}
 
 			string oldBackupDirectory = Path.Combine(targetDirectory, SharedInfo.UpdateDirectoryOld);
 
 			if (Directory.Exists(oldBackupDirectory)) {
-				ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				if (!updateCleanup) {
+					updateCleanup = true;
+
+					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
+				}
 
 				await DeletePotentiallyUsedDirectory(oldBackupDirectory).ConfigureAwait(false);
-
-				ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 			}
 		} catch (Exception e) {
 			ASF.ArchiLogger.LogGenericException(e);
 
 			return false;
+		}
+
+		if (updateCleanup) {
+			ASF.ArchiLogger.LogGenericInfo(Strings.Done);
 		}
 
 		return true;

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -489,7 +489,7 @@ public static class Utilities {
 					break;
 			}
 
-			// We're going to move this file out of the current place
+			// We're going to move this file out of the current place, overwriting existing one if needed
 			string targetBackupDirectory;
 
 			if (relativeDirectoryName.Length > 0) {
@@ -504,7 +504,7 @@ public static class Utilities {
 
 			string targetBackupFile = Path.Combine(targetBackupDirectory, fileName);
 
-			File.Move(file, targetBackupFile);
+			File.Move(file, targetBackupFile, true);
 		}
 
 		// Finally, we can move the newly extracted files to target directory

--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -183,9 +183,7 @@ internal static class Logging {
 
 		if (uniqueInstance) {
 			try {
-				if (!Directory.Exists(SharedInfo.ArchivalLogsDirectory)) {
-					Directory.CreateDirectory(SharedInfo.ArchivalLogsDirectory);
-				}
+				Directory.CreateDirectory(SharedInfo.ArchivalLogsDirectory);
 			} catch (Exception e) {
 				ASF.ArchiLogger.LogGenericException(e);
 			}

--- a/ArchiSteamFarm/Plugins/PluginsCore.cs
+++ b/ArchiSteamFarm/Plugins/PluginsCore.cs
@@ -780,7 +780,7 @@ public static class PluginsCore {
 				string? relativeAssemblyDirectoryName = Path.GetFileName(relativeAssemblyDirectory);
 
 				while (!string.IsNullOrEmpty(relativeAssemblyDirectoryName)) {
-					if ((relativeAssemblyDirectoryName == SharedInfo.UpdateDirectoryOld) || relativeAssemblyDirectoryName.StartsWith(SharedInfo.UpdateDirectoryOldPrefix, StringComparison.Ordinal) || relativeAssemblyDirectoryName.StartsWith(SharedInfo.UpdateDirectoryNewPrefix, StringComparison.Ordinal)) {
+					if (relativeAssemblyDirectoryName is SharedInfo.UpdateDirectoryOld or SharedInfo.UpdateDirectoryNew) {
 						skip = true;
 
 						break;

--- a/ArchiSteamFarm/Plugins/PluginsCore.cs
+++ b/ArchiSteamFarm/Plugins/PluginsCore.cs
@@ -844,36 +844,8 @@ public static class PluginsCore {
 				throw new InvalidOperationException(nameof(assemblyDirectory));
 			}
 
-			try {
-				// If directories from previous update exist, it's a good idea to purge them now
-				foreach (string directory in Directory.EnumerateDirectories(assemblyDirectory, $"{SharedInfo.UpdateDirectoryNewPrefix}*")) {
-					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					Directory.Delete(directory, true);
-
-					ASF.ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-
-				foreach (string directory in Directory.EnumerateDirectories(assemblyDirectory, $"{SharedInfo.UpdateDirectoryOldPrefix}*")) {
-					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					await Utilities.DeletePotentiallyUsedDirectory(directory).ConfigureAwait(false);
-
-					ASF.ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-
-				string backupDirectory = Path.Combine(assemblyDirectory, SharedInfo.UpdateDirectoryOld);
-
-				if (Directory.Exists(backupDirectory)) {
-					ASF.ArchiLogger.LogGenericInfo(Strings.UpdateCleanup);
-
-					await Utilities.DeletePotentiallyUsedDirectory(backupDirectory).ConfigureAwait(false);
-
-					ASF.ArchiLogger.LogGenericInfo(Strings.Done);
-				}
-			} catch (Exception e) {
-				ASF.ArchiLogger.LogGenericException(e);
-
+			// If directories from previous update exist, it's a good idea to purge them now
+			if (!await Utilities.UpdateCleanup(assemblyDirectory).ConfigureAwait(false)) {
 				return false;
 			}
 

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -415,30 +415,25 @@ internal static class Program {
 
 		// If debugging is on, we prepare debug directory prior to running
 		if (Debugging.IsUserDebugging) {
-			if (Debugging.IsDebugConfigured) {
-				ASF.ArchiLogger.LogGenericDebug($"{globalDatabaseFile}: {globalDatabase.ToJsonText(true)}");
-			}
-
 			Logging.EnableTraceLogging();
 
 			if (Debugging.IsDebugConfigured) {
+				ASF.ArchiLogger.LogGenericDebug($"{globalDatabaseFile}: {globalDatabase.ToJsonText(true)}");
+
 				DebugLog.AddListener(new Debugging.DebugListener());
 				DebugLog.Enabled = true;
 
-				if (Directory.Exists(SharedInfo.DebugDirectory)) {
-					try {
-						Directory.Delete(SharedInfo.DebugDirectory, true);
-						await Task.Delay(1000).ConfigureAwait(false); // Dirty workaround giving Windows some time to sync
-					} catch (Exception e) {
-						ASF.ArchiLogger.LogGenericException(e);
-					}
+				if (!await Utilities.EnsureUpdateDirectoriesPurged(SharedInfo.DebugDirectory).ConfigureAwait(false)) {
+					return false;
 				}
-			}
 
-			try {
-				Directory.CreateDirectory(SharedInfo.DebugDirectory);
-			} catch (Exception e) {
-				ASF.ArchiLogger.LogGenericException(e);
+				try {
+					Directory.CreateDirectory(SharedInfo.DebugDirectory);
+				} catch (Exception e) {
+					ASF.ArchiLogger.LogGenericException(e);
+
+					return false;
+				}
 			}
 		}
 

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -428,8 +428,6 @@ internal static class Program {
 					Directory.CreateDirectory(ASF.DebugDirectory);
 				} catch (Exception e) {
 					ASF.ArchiLogger.LogGenericException(e);
-
-					return false;
 				}
 			}
 		}

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -421,14 +421,11 @@ internal static class Program {
 				ASF.ArchiLogger.LogGenericDebug($"{globalDatabaseFile}: {globalDatabase.ToJsonText(true)}");
 
 				DebugLog.AddListener(new Debugging.DebugListener());
+
 				DebugLog.Enabled = true;
 
-				if (!await Utilities.EnsureUpdateDirectoriesPurged(SharedInfo.DebugDirectory).ConfigureAwait(false)) {
-					return false;
-				}
-
 				try {
-					Directory.CreateDirectory(SharedInfo.DebugDirectory);
+					Directory.CreateDirectory(ASF.DebugDirectory);
 				} catch (Exception e) {
 					ASF.ArchiLogger.LogGenericException(e);
 

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -68,8 +68,9 @@ public static class SharedInfo {
 	internal const string ProjectURL = $"https://github.com/{GithubRepo}";
 	internal const ushort ShortInformationDelay = InformationDelay / 2;
 	internal const string UlongCompatibilityStringPrefix = "s_";
-	internal const string UpdateDirectoryNew = "_new";
+	internal const string UpdateDirectoryNewPrefix = "_new-";
 	internal const string UpdateDirectoryOld = "_old";
+	internal const string UpdateDirectoryOldPrefix = "_old-";
 	internal const string WebsiteDirectory = "www";
 
 	[PublicAPI]

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -68,9 +68,8 @@ public static class SharedInfo {
 	internal const string ProjectURL = $"https://github.com/{GithubRepo}";
 	internal const ushort ShortInformationDelay = InformationDelay / 2;
 	internal const string UlongCompatibilityStringPrefix = "s_";
-	internal const string UpdateDirectoryNewPrefix = "_new-";
+	internal const string UpdateDirectoryNew = "_new";
 	internal const string UpdateDirectoryOld = "_old";
-	internal const string UpdateDirectoryOldPrefix = "_old-";
 	internal const string WebsiteDirectory = "www";
 
 	[PublicAPI]

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -68,7 +68,8 @@ public static class SharedInfo {
 	internal const string ProjectURL = $"https://github.com/{GithubRepo}";
 	internal const ushort ShortInformationDelay = InformationDelay / 2;
 	internal const string UlongCompatibilityStringPrefix = "s_";
-	internal const string UpdateDirectory = "_old";
+	internal const string UpdateDirectoryNew = "_new";
+	internal const string UpdateDirectoryOld = "_old";
 	internal const string WebsiteDirectory = "www";
 
 	[PublicAPI]

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -354,11 +354,12 @@ public sealed class Bot : IAsyncDisposable, IDisposable {
 		// Initialize
 		SteamClient = new SteamClient(SteamConfiguration, botName);
 
-		if (Debugging.IsDebugConfigured && Directory.Exists(SharedInfo.DebugDirectory)) {
-			string debugListenerPath = Path.Combine(SharedInfo.DebugDirectory, botName);
+		if (Debugging.IsDebugConfigured && Directory.Exists(ASF.DebugDirectory)) {
+			string debugListenerPath = Path.Combine(ASF.DebugDirectory, botName);
 
 			try {
 				Directory.CreateDirectory(debugListenerPath);
+
 				SteamClient.DebugNetworkListener = new NetHookNetworkListener(debugListenerPath, SteamClient);
 			} catch (Exception e) {
 				ArchiLogger.LogGenericException(e);


### PR DESCRIPTION
This PR changes the update procedure to far more robust and universal solution:

Old method:
- Moved target directory files to `_old`
- Extracted zip archive files to target directory

New method:
- Extracts zip archive files to `_new`
- Moves target directory files to `_old`
- Moves `_new` files to target directory

Code review welcome. I've tested this with plugins update as well as ASF update and found everything to be working as it should.

Potential improvement for the future (totally outside of scope of this PR) will be to start extracting of zip file as the stream is downloaded. But this can wait, firstly we need to get new update procedure right.

Closes #3156