### PR TITLE
Fix monitoring integration with actual prometheus

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
 	},
 	"packageRules": [
 		{
-			// TODO: <= 1.7.0-rc.1 for invalid response on monitoring endpoint, last failed version 1.8.0-rc.1
+			// TODO: <= 1.7.0-rc.1 for invalid response on monitoring endpoint, last failed version 1.8.0-rc.1 - https://github.com/open-telemetry/opentelemetry-dotnet/issues/5506
 			"allowedVersions": "<= 1.7.0-rc.1",
 			"matchManagers": [ "nuget" ],
 			"matchPackageNames": [ "OpenTelemetry.Exporter.Prometheus.AspNetCore" ]

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,12 @@
 			"allowedVersions": "<= 3.1",
 			"matchManagers": [ "nuget" ],
 			"matchPackageNames": [ "Microsoft.Extensions.Configuration.Json", "Microsoft.Extensions.Logging.Configuration" ]
+		},
+		{
+			// TODO: <= 1.7.0-rc.1 for invalid response on monitoring endpoint, last failed version 1.8.0-rc.1
+			"allowedVersions": "<= 1.7.0-rc.1",
+			"matchManagers": [ "nuget" ],
+			"matchPackageNames": [ "OpenTelemetry.Exporter.Prometheus.AspNetCore" ]
 		}
 	]
 }

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -156,7 +156,8 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IWebServiceProvider, IG
 
 				return bots.Select(static bot => new Measurement<double>(bot.CardsFarmer.TimeRemaining.TotalMinutes, new KeyValuePair<string, object?>(TagNames.BotName, bot.BotName), new KeyValuePair<string, object?>(TagNames.SteamID, bot.SteamID)));
 			},
-			description: "Approximate number of minutes remaining until each bot has finished farming all cards"
+			Units.Minutes,
+			"Approximate number of minutes remaining until each bot has finished farming all cards"
 		);
 
 		Meter.CreateObservableGauge(

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -150,8 +150,9 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IWebServiceProvider, IG
 			description: "Number of Steam groups each bot is in"
 		);
 
+		// Keep in mind that we use a unit here and the unit needs to be a suffix to the name
 		Meter.CreateObservableGauge(
-			$"{MetricNamePrefix}_bot_farming_minutes_remaining", static () => {
+			$"{MetricNamePrefix}_bot_farming_time_remaining_{Units.Minutes}", static () => {
 				ICollection<Bot> bots = Bot.Bots?.Values ?? Array.Empty<Bot>();
 
 				return bots.Select(static bot => new Measurement<double>(bot.CardsFarmer.TimeRemaining.TotalMinutes, new KeyValuePair<string, object?>(TagNames.BotName, bot.BotName), new KeyValuePair<string, object?>(TagNames.SteamID, bot.SteamID)));

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -55,8 +55,7 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IWebServiceProvider, IG
 		new(
 			1,
 			new KeyValuePair<string, object?>(TagNames.Version, SharedInfo.Version.ToString()),
-			new KeyValuePair<string, object?>(TagNames.Variant, SharedInfo.BuildInfo.Variant),
-			new KeyValuePair<string, object?>(TagNames.ModuleVersion, SharedInfo.ModuleVersion.ToString())
+			new KeyValuePair<string, object?>(TagNames.Variant, SharedInfo.BuildInfo.Variant)
 		);
 
 	private static readonly Measurement<int> RuntimeInfo = CreateRuntimeInformation();

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/TagNames.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/TagNames.cs
@@ -28,7 +28,6 @@ internal static class TagNames {
 	internal const string BotState = "state";
 	internal const string CurrencyCode = "currency";
 	internal const string Framework = "framework";
-	internal const string ModuleVersion = "module_version";
 	internal const string OS = "operating_system";
 	internal const string Runtime = "runtime";
 	internal const string SteamID = "steamid";

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/TagNames.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/TagNames.cs
@@ -27,5 +27,11 @@ internal static class TagNames {
 	internal const string BotName = "bot";
 	internal const string BotState = "state";
 	internal const string CurrencyCode = "currency";
+	internal const string Framework = "framework";
+	internal const string ModuleVersion = "module_version";
+	internal const string OS = "operating_system";
+	internal const string Runtime = "runtime";
 	internal const string SteamID = "steamid";
+	internal const string Variant = "variant";
+	internal const string Version = "version";
 }

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/Units.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/Units.cs
@@ -1,0 +1,28 @@
+// ----------------------------------------------------------------------------------------------
+//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// ----------------------------------------------------------------------------------------------
+// |
+// Copyright 2015-2024 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace ArchiSteamFarm.OfficialPlugins.Monitoring;
+
+internal static class Units {
+	internal const string Minutes = "minutes";
+}

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -43,31 +43,13 @@ namespace ArchiSteamFarm.Core;
 
 internal static class OS {
 	[PublicAPI]
-	public static string? Description {
-		get {
-			string description = RuntimeInformation.OSDescription.Trim();
-
-			return description.Length == 0 ? null : description;
-		}
-	}
+	public static string? Description => TrimAndNullifyEmptyString(RuntimeInformation.OSDescription);
 
 	[PublicAPI]
-	public static string? Framework {
-		get {
-			string framework = RuntimeInformation.FrameworkDescription.Trim();
-
-			return framework.Length == 0 ? null : framework;
-		}
-	}
+	public static string? Framework => TrimAndNullifyEmptyString(RuntimeInformation.FrameworkDescription);
 
 	[PublicAPI]
-	public static string? Runtime {
-		get {
-			string runtime = RuntimeInformation.RuntimeIdentifier.Trim();
-
-			return runtime.Length == 0 ? null : runtime;
-		}
-	}
+	public static string? Runtime => TrimAndNullifyEmptyString(RuntimeInformation.RuntimeIdentifier);
 
 	// We need to keep this one assigned and not calculated on-demand
 	internal static readonly string ProcessFileName = Environment.ProcessPath ?? throw new InvalidOperationException(nameof(ProcessFileName));
@@ -304,6 +286,14 @@ internal static class OS {
 				NativeMethods.ShowWindow(windowHandle, NativeMethods.EShowWindow.Minimize);
 			}
 		}
+	}
+
+	private static string? TrimAndNullifyEmptyString(string s) {
+		ArgumentNullException.ThrowIfNull(s);
+
+		s = s.Trim();
+
+		return s.Length == 0 ? null : s;
 	}
 
 	[SupportedOSPlatform("Windows")]

--- a/ArchiSteamFarm/Core/OS.cs
+++ b/ArchiSteamFarm/Core/OS.cs
@@ -37,10 +37,38 @@ using System.Threading.Tasks;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.Storage;
 using ArchiSteamFarm.Web;
+using JetBrains.Annotations;
 
 namespace ArchiSteamFarm.Core;
 
 internal static class OS {
+	[PublicAPI]
+	public static string? Description {
+		get {
+			string description = RuntimeInformation.OSDescription.Trim();
+
+			return description.Length == 0 ? null : description;
+		}
+	}
+
+	[PublicAPI]
+	public static string? Framework {
+		get {
+			string framework = RuntimeInformation.FrameworkDescription.Trim();
+
+			return framework.Length == 0 ? null : framework;
+		}
+	}
+
+	[PublicAPI]
+	public static string? Runtime {
+		get {
+			string runtime = RuntimeInformation.RuntimeIdentifier.Trim();
+
+			return runtime.Length == 0 ? null : runtime;
+		}
+	}
+
 	// We need to keep this one assigned and not calculated on-demand
 	internal static readonly string ProcessFileName = Environment.ProcessPath ?? throw new InvalidOperationException(nameof(ProcessFileName));
 
@@ -58,25 +86,7 @@ internal static class OS {
 				return BackingVersion;
 			}
 
-			string framework = RuntimeInformation.FrameworkDescription.Trim();
-
-			if (framework.Length == 0) {
-				framework = "Unknown Framework";
-			}
-
-			string runtime = RuntimeInformation.RuntimeIdentifier.Trim();
-
-			if (runtime.Length == 0) {
-				runtime = "Unknown Runtime";
-			}
-
-			string description = RuntimeInformation.OSDescription.Trim();
-
-			if (description.Length == 0) {
-				description = "Unknown OS";
-			}
-
-			BackingVersion = $"{framework}; {runtime}; {description}";
+			BackingVersion = $"{Framework ?? "Unknown Framework"}; {Runtime ?? "Unknown Runtime"}; {Description ?? "Unknown OS"}";
 
 			return BackingVersion;
 		}

--- a/ArchiSteamFarm/SharedInfo.cs
+++ b/ArchiSteamFarm/SharedInfo.cs
@@ -101,7 +101,7 @@ public static class SharedInfo {
 	internal static string PublicIdentifier => $"{AssemblyName}{(BuildInfo.IsCustomBuild ? "-custom" : PluginsCore.HasCustomPluginsLoaded ? "-modded" : "")}";
 	internal static Version Version => Assembly.GetExecutingAssembly().GetName().Version ?? throw new InvalidOperationException(nameof(Version));
 
-	private static Guid ModuleVersion => Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
+	internal static Guid ModuleVersion => Assembly.GetExecutingAssembly().ManifestModule.ModuleVersionId;
 
 	private static string? CachedHomeDirectory;
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,9 +12,9 @@
 		<PackageVersion Include="NLog.Web.AspNetCore" Version="5.3.8" />
 		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
 		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.0" />
+		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
 		<PackageVersion Include="SteamKit2" Version="3.0.0-Alpha.1" />
 		<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
 		<PackageVersion Include="MSTest" Version="3.3.0" />
 		<PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
 		<PackageVersion Include="NLog.Web.AspNetCore" Version="5.3.8" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.8.0-rc.1" />
+		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
 		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.0" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
 		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Downgrades `OpenTelemetry.Exporter.Prometheus.AspNetCore` from `1.8.0-rc.1` to `1.7.0-rc.1` due to issues in providing valid metrics via its endpoint. Also disables automatic upgrades by renovate bot.

Additionally the one metric where it makes sense now has a unit added and some of the other packages are upgraded (so renovate bot has less work).

## Additional info

I've already verified this to work with generic ASF `6.0.2.0`.

After I have official binaries I'll let it run for a few days and create a dashboard and screenshots. Dashboard we can potentially integrate in the repository itself. Screenshots might be useful for the first draft of wiki page (you already got that from me).

---

Thank you for considering the inclusion of this merge request.