### PR TITLE
Fix monitoring plugin

### DIFF
--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -198,7 +198,7 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IDisposable, IGitHubPlu
 			$"{MetricNamePrefix}_bot_farming_time_remaining_{Units.Minutes}", static () => {
 				IEnumerable<Bot> bots = Bot.Bots?.Values ?? [];
 
-				return bots.Select(static bot => new Measurement<double>(bot.CardsFarmer.TimeRemaining.TotalMinutes, new KeyValuePair<string, object?>(TagNames.BotName, bot.BotName), new KeyValuePair<string, object?>(TagNames.SteamID, bot.SteamID)));
+				return bots.Where(static bot => bot.IsConnectedAndLoggedOn).Select(static bot => new Measurement<double>(bot.CardsFarmer.TimeRemaining.TotalMinutes, new KeyValuePair<string, object?>(TagNames.BotName, bot.BotName), new KeyValuePair<string, object?>(TagNames.SteamID, bot.SteamID)));
 			},
 			Units.Minutes,
 			"Approximate number of minutes remaining until each bot has finished farming all cards"

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -77,8 +77,6 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IDisposable, IGitHubPlu
 	[Required]
 	public override Version Version => typeof(MonitoringPlugin).Assembly.GetName().Version ?? throw new InvalidOperationException(nameof(Version));
 
-	public string WebPath => "/monitoring";
-
 	private Meter? Meter;
 
 	public void Dispose() => Meter?.Dispose();

--- a/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
+++ b/ArchiSteamFarm.OfficialPlugins.Monitoring/MonitoringPlugin.cs
@@ -77,6 +77,8 @@ internal sealed class MonitoringPlugin : OfficialPlugin, IDisposable, IGitHubPlu
 	[Required]
 	public override Version Version => typeof(MonitoringPlugin).Assembly.GetName().Version ?? throw new InvalidOperationException(nameof(Version));
 
+	public string WebPath => "/monitoring";
+
 	private Meter? Meter;
 
 	public void Dispose() => Meter?.Dispose();

--- a/ArchiSteamFarm/Plugins/PluginsCore.cs
+++ b/ArchiSteamFarm/Plugins/PluginsCore.cs
@@ -304,8 +304,10 @@ public static class PluginsCore {
 			}
 		}
 
-		if (activePluginUpdates.Any(static plugin => plugin is not OfficialPlugin)) {
-			ASF.ArchiLogger.LogGenericWarning(Strings.CustomPluginUpdatesEnabled);
+		if (activePluginUpdates.Count > 0) {
+			if (activePluginUpdates.Any(static plugin => plugin is not OfficialPlugin)) {
+				ASF.ArchiLogger.LogGenericWarning(Strings.CustomPluginUpdatesEnabled);
+			}
 
 			ActivePluginUpdates = activePluginUpdates.ToFrozenSet();
 		}

--- a/ArchiSteamFarm/Plugins/PluginsCore.cs
+++ b/ArchiSteamFarm/Plugins/PluginsCore.cs
@@ -304,7 +304,7 @@ public static class PluginsCore {
 			}
 		}
 
-		if (activePluginUpdates.Count > 0) {
+		if (activePluginUpdates.Any(static plugin => plugin is not OfficialPlugin)) {
 			ASF.ArchiLogger.LogGenericWarning(Strings.CustomPluginUpdatesEnabled);
 
 			ActivePluginUpdates = activePluginUpdates.ToFrozenSet();


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Fixed ASF crash due to `WebPath` being `"/"` crashing ASF [here](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/ArchiSteamFarm/IPC/ArchiKestrel.cs#L201).

Related commit: [49618534ce8f8b840f4d4cb641f5f2fa102841b3](https://github.com/JustArchiNET/ArchiSteamFarm/commit/49618534ce8f8b840f4d4cb641f5f2fa102841b3)

Additionally, metric about remaining farming time is now only published for bots that are actually connected and logged in and the warning about automatic updates of custom plugins now is disabled if there is only official plugins enabled for automatic updates.

## Additional info

Requires update of our wikis last paragraph about monitoring plugin to say `/monitoring/grafana-dashboard.json` instead of `/grafana-dashboard.json`.



I would like to request for official plugins to be updated automatically - ignoring plugin update settings - as outdated official plugin will crash ASF (unless `--ignore-unsupported-environment` is set). Otherwise I recommend at least mentioning correct settings and implications of its non-existance on corresponding wiki page.