### PR TITLE
Ensure file permissions on gnu/linux

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -17,6 +17,7 @@
 		<PackageReference Include="JetBrains.Annotations" PrivateAssets="all" />
 		<PackageReference Include="Markdig.Signed" />
 		<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
+		<PackageReference Include="Mono.Posix.NETStandard" />
 		<PackageReference Include="Nito.AsyncEx.Coordination" />
 		<PackageReference Include="NLog.Web.AspNetCore" />
 		<PackageReference Include="SteamKit2" />

--- a/ArchiSteamFarm/Helpers/SerializableFile.cs
+++ b/ArchiSteamFarm/Helpers/SerializableFile.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using ArchiSteamFarm.Core;
 using ArchiSteamFarm.Helpers.Json;
 using JetBrains.Annotations;
+using Mono.Unix.Native;
 
 namespace ArchiSteamFarm.Helpers;
 
@@ -119,6 +120,12 @@ public abstract class SerializableFile : IDisposable {
 
 				File.Move(newFilePath, serializableFile.FilePath);
 			}
+
+			// Ensure file permissions on gnu/linux
+            if (!OperatingSystem.IsWindows()) {
+            	Syscall.chmod(serializableFile.FilePath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
+            }
+
 		} catch (Exception e) {
 			ASF.ArchiLogger.LogGenericException(e);
 		} finally {
@@ -169,6 +176,11 @@ public abstract class SerializableFile : IDisposable {
 
 				File.Move(newFilePath, filePath);
 			}
+
+			// Ensure file permissions on gnu/linux
+            if (!OperatingSystem.IsWindows()) {
+            	Syscall.chmod(filePath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
+            }
 
 			return true;
 		} catch (Exception e) {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,26 +1,27 @@
 <Project>
-	<ItemGroup>
-		<PackageVersion Include="AngleSharp.XPath" Version="2.0.4" />
-		<PackageVersion Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" />
-		<PackageVersion Include="CryptSharpStandard" Version="1.0.0" />
-		<PackageVersion Include="Humanizer" Version="3.0.0-beta.54" />
-		<PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
-		<PackageVersion Include="Markdig.Signed" Version="0.37.0" />
-		<PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.0" />
-		<PackageVersion Include="MSTest" Version="3.4.3" />
-		<PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
-		<PackageVersion Include="NLog.Web.AspNetCore" Version="5.3.11" />
-		<PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
-		<PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
-		<PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
-		<PackageVersion Include="SteamKit2" Version="3.0.0-Alpha.1" />
-		<PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-		<PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
-		<PackageVersion Include="System.Composition" Version="8.0.0" />
-		<PackageVersion Include="System.Composition.AttributedModel" Version="8.0.0" />
-		<PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-		<PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="AngleSharp.XPath" Version="2.0.4" />
+    <PackageVersion Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1" />
+    <PackageVersion Include="CryptSharpStandard" Version="1.0.0" />
+    <PackageVersion Include="Humanizer" Version="3.0.0-beta.54" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
+    <PackageVersion Include="Markdig.Signed" Version="0.37.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="7.6.0" />
+    <PackageVersion Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageVersion Include="MSTest" Version="3.4.3" />
+    <PackageVersion Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
+    <PackageVersion Include="NLog.Web.AspNetCore" Version="5.3.11" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.7.0-rc.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.1" />
+    <PackageVersion Include="SteamKit2" Version="3.0.0-Alpha.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="6.6.2" />
+    <PackageVersion Include="System.Composition" Version="8.0.0" />
+    <PackageVersion Include="System.Composition.AttributedModel" Version="8.0.0" />
+    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [ ] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [+] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [+] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [ ] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] I have added tests to cover my changes, wherever they are necessary.
- [ ] All new and existing tests pass.

## Changes

Config files in gnu/linux are now being created with reasonable permissions, so that only the user owning the asf directory can read file contents and no one else

### Changed functionality

SerializableFile Helper now applies reasonable permissions on config files after migration in gnu/linux