### PR TITLE
Fix struct reordering

### DIFF
--- a/ArchiSteamFarm.sln.DotSettings
+++ b/ArchiSteamFarm.sln.DotSettings
@@ -524,6 +524,22 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/XmlFormatter/WRAP_LINES/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
+  &lt;TypePattern DisplayName=&quot;Non-reorderable types&quot; Priority=&quot;99999999&quot;&gt;
+    &lt;TypePattern.Match&gt;
+      &lt;Or&gt;
+        &lt;And&gt;
+          &lt;Kind Is=&quot;Interface&quot; /&gt;
+          &lt;Or&gt;
+            &lt;HasAttribute Name=&quot;System.Runtime.InteropServices.InterfaceTypeAttribute&quot; /&gt;
+            &lt;HasAttribute Name=&quot;System.Runtime.InteropServices.ComImport&quot; /&gt;
+          &lt;/Or&gt;
+        &lt;/And&gt;
+        &lt;Kind Is=&quot;Struct&quot; /&gt;
+        &lt;HasAttribute Name=&quot;System.Runtime.InteropServices.StructLayoutAttribute&quot; /&gt;
+        &lt;HasAttribute Name=&quot;JetBrains.Annotations.NoReorderAttribute&quot; /&gt;
+      &lt;/Or&gt;
+    &lt;/TypePattern.Match&gt;
+  &lt;/TypePattern&gt;
   &lt;TypePattern DisplayName="ArchiPattern" Priority="150"&gt;&#xD;
     &lt;Entry DisplayName="Public (Events and Delegates)"&gt;&#xD;
       &lt;Entry.Match&gt;&#xD;

--- a/ArchiSteamFarm/Core/NativeMethods.cs
+++ b/ArchiSteamFarm/Core/NativeMethods.cs
@@ -108,12 +108,10 @@ internal static partial class NativeMethods {
 	[StructLayout(LayoutKind.Sequential)]
 	[SupportedOSPlatform("Windows")]
 	internal struct FlashWindowInfo {
-#pragma warning disable Reordering // TODO: This silly pragma doesn't do anything, but it stops Rider from reordering, we may be able to get rid of it later
 		public uint StructSize;
 		public nint WindowHandle;
 		public EFlashFlags Flags;
 		public uint Count;
 		public uint TimeoutBetweenFlashes;
-#pragma warning restore Reordering // TODO: This silly pragma doesn't do anything, but it stops Rider from reordering, we may be able to get rid of it later
 	}
 }


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

None

### Changed functionality

No user-facing changes, a reordering pattern in DotSettings was modified to make sure that the order of the fields is persisted in the types where it is important (e.g. types with `StructLayout` attribute)

### Removed functionality

None

## Additional info

probably this could be fixed long before the new EAP was released but well