### PR TITLE
Add `loot&` and `transfer&` commands

### DIFF
--- a/ArchiSteamFarm/Steam/Data/EAssetRarity.cs
+++ b/ArchiSteamFarm/Steam/Data/EAssetRarity.cs
@@ -20,7 +20,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 namespace ArchiSteamFarm.Steam.Data;
 

--- a/ArchiSteamFarm/Steam/Data/EAssetRarity.cs
+++ b/ArchiSteamFarm/Steam/Data/EAssetRarity.cs
@@ -20,12 +20,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
 namespace ArchiSteamFarm.Steam.Data;
 
+#pragma warning disable CA1027 // Aliases are intentional, we don't plan to combine fields
 public enum EAssetRarity : byte {
 	Unknown,
 	Common,
 	Uncommon,
-	Rare
+	Rare,
+	Mythical,
+	Epic = Mythical,
+	Legendary,
+	Exotic = Legendary,
+	Ancient,
+	Extraordinary = Ancient,
+	Immortal,
+	Contraband = Immortal,
+	Arcana,
+	Unusual
 }
+#pragma warning restore CA1027 // Aliases are intentional, we don't plan to combine fields

--- a/ArchiSteamFarm/Steam/Data/InventoryDescription.cs
+++ b/ArchiSteamFarm/Steam/Data/InventoryDescription.cs
@@ -191,8 +191,8 @@ public sealed class InventoryDescription {
 			}
 
 			foreach (CEconItem_Tag? tag in Body.tags) {
-				switch (tag.category) {
-					case "droprate":
+				switch (tag.category.ToUpperInvariant()) {
+					case "DROPRATE":
 						switch (tag.internal_name) {
 							case "droprate_0":
 								CachedRarity = EAssetRarity.Common;
@@ -213,6 +213,20 @@ public sealed class InventoryDescription {
 
 								return CachedRarity.Value;
 						}
+					case "RARITY":
+						string internalName = tag.internal_name.Split('_', StringSplitOptions.RemoveEmptyEntries).Skip(1).FirstOrDefault() ?? tag.internal_name;
+
+						if (Enum.TryParse<EAssetRarity>(internalName, true, out EAssetRarity assetRarity)) {
+							CachedRarity = assetRarity;
+
+							return CachedRarity.Value;
+						}
+
+						ASF.ArchiLogger.LogGenericError(Strings.FormatWarningUnknownValuePleaseReport(nameof(tag.internal_name), tag.internal_name));
+
+						CachedRarity = EAssetRarity.Unknown;
+
+						return CachedRarity.Value;
 				}
 			}
 


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

Adds two derivatives of `loot^` and `transfer^` commands: `loot&` and `transfer&`, allowing one to transfer Steam items that match user-provided set of `EAssetRarity`.

## Additional info

This implementation expands the current `EAssetRarity` enum with rarities inherent in official Valve games, namely: [CS2](https://raw.githubusercontent.com/SteamDatabase/GameTracking-CS2/master/game/csgo/pak01_dir/scripts/items/items_game.txt), [DOTA2](https://raw.githubusercontent.com/muk-as/DOTA2_CLIENT/master/game/dota/pak01_dir/scripts/items/items_game.txt) and [TF2](https://raw.githubusercontent.com/SteamDatabase/GameTracking-TF2/master/tf/scripts/items/items_game.txt), as well as some non-Valve games that I'm somewhat familiar with (eg. [PAYDAY2](https://steamdb.info/app/218620/items)). Covering every possible item rarity in non-Valve games that support [Steam Inventory Service](https://partner.steamgames.com/doc/features/inventory) is pretty unrealistic since, to my knowledge, there's no strict naming conventions.

Some clarifications:
- `Seasonal` (DOTA2) and `Default` rarities are intentionally omitted, they are not tradable.
- `tag.category.ToUpperInvariant()` is used because non-Valve games tend to have lowercase `rarity` category. Conversely, the same category in Valve games is `Rarity`.

Also, I'm not sure about `Arcana` rarity. It is DOTA2 specific, maybe it would be better to combine it with `Unusual`? Would greatly appreciate any kind of feedback.