### PR TITLE
fix localization-resx-generation

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<DefaultItemExcludes>$(DefaultItemExcludes);config/**;debug/**;logs/**;overlay/**</DefaultItemExcludes>
 		<OutputType>Exe</OutputType>
+		<EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -27,9 +28,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<EmbeddedResource Update="Localization\Strings.resx" EmitFormatMethods="true" Public="true" />
+		<EmbeddedResource Include="Localization\Strings.resx" EmitFormatMethods="true" Public="true" />
+		<EmbeddedResource Include="Localization\Strings.*.resx" Exclude="Localization\Strings.resx">
+			<GenerateSource>false</GenerateSource>
+		</EmbeddedResource>
 	</ItemGroup>
-
 	<ItemGroup>
 		<Content Include="..\LICENSE.txt">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

<!-- Please describe below, what new functionality was added. -->

### Changed functionality

<!-- Please describe below, what old functionality was changed. -->

### Removed functionality

<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
This branch addresses compilation errors (CS0101, CS0116) and restores localization functionality. The fix involves precisely
  configuring the .csproj file to manage Microsoft.CodeAnalysis.ResxSourceGenerator behavior for resource files. Specifically, it
  disables default embedded resource item inclusion, explicitly includes the main Strings.resx for C# code generation, and explicitly
  includes localized Strings.*.resx files as embedded resources while preventing the source generator from creating duplicate C#
  classes for them.