### PR TITLE
trade offer signature config

### DIFF
--- a/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/Steam/Integration/ArchiWebHandler.cs
@@ -637,8 +637,14 @@ public sealed class ArchiWebHandler : IDisposable {
 				singleTrade.ItemsToReceive.Assets.Add(itemToReceive);
 			}
 		}
+		string defaultTradeOfferSignature = $"Sent by {SharedInfo.PublicIdentifier}/{SharedInfo.Version}";
+		string tradeOfferSignature = ASF.GlobalConfig?.TradeOfferSignature ?? defaultTradeOfferSignature;
 
-		string tradeOfferMessage = $"Sent by {SharedInfo.PublicIdentifier}/{SharedInfo.Version}";
+		if (tradeOfferSignature.Length > MaxTradeOfferMessageLength) {
+			Bot.ArchiLogger.LogGenericWarning(Strings.FormatWarningFailedWithError(Strings.FormatErrorConfigPropertyInvalid(nameof(ASF.GlobalConfig.TradeOfferSignature), tradeOfferSignature)));
+			tradeOfferSignature = defaultTradeOfferSignature;
+		}
+		string tradeOfferMessage = tradeOfferSignature;
 
 		if (!string.IsNullOrEmpty(customMessage)) {
 			byte allowedExtraMessageLength = (byte) (MaxTradeOfferMessageLength - tradeOfferMessage.Length - 3); // We're going to add a space, opening and closing bracket

--- a/ArchiSteamFarm/Storage/GlobalConfig.cs
+++ b/ArchiSteamFarm/Storage/GlobalConfig.cs
@@ -139,6 +139,9 @@ public sealed class GlobalConfig {
 	public const string? DefaultWebProxyText = null;
 
 	[PublicAPI]
+	public const string? DefaultTradeOfferSignature = null;
+
+	[PublicAPI]
 	public const string? DefaultWebProxyUsername = null;
 
 	[PublicAPI]
@@ -332,6 +335,9 @@ public sealed class GlobalConfig {
 	public string? WebProxyText { get; init; } = DefaultWebProxyText;
 
 	[JsonInclude]
+	public string? TradeOfferSignature { get; init; } = DefaultTradeOfferSignature;
+
+	[JsonInclude]
 	public string? WebProxyUsername { get; init; } = DefaultWebProxyUsername;
 
 	[JsonExtensionData]
@@ -470,6 +476,9 @@ public sealed class GlobalConfig {
 
 	[UsedImplicitly]
 	public bool ShouldSerializeWebLimiterDelay() => !Saving || (WebLimiterDelay != DefaultWebLimiterDelay);
+
+	[UsedImplicitly]
+	public bool ShouldSerializeTradeOfferSignature() => !Saving || (TradeOfferSignature != DefaultTradeOfferSignature);
 
 	[UsedImplicitly]
 	public bool ShouldSerializeWebProxyPassword() => Saving && IsWebProxyPasswordSet && (WebProxyPassword != DefaultWebProxyPassword);


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [ ] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [ ] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] I have added tests to cover my changes, wherever they are necessary.
- [ ] All new and existing tests pass.

## Changes

### New functionality
TradeOffer
<!-- Please describe below, what new functionality was added. -->

### Changed functionality


<!-- Please describe below, what old functionality was changed. -->

### Removed functionality

<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
 This PR introduces a new TradeOfferSignature property in the global configuration, enabling users to customize the message sent with
  trade offers.

  Previously, the trade offer message was hardcoded as "Sent by {SharedInfo.PublicIdentifier}/{SharedInfo.Version}". This change
  provides flexibility for users who wish to use a different signature or attribution.

  Key changes:
   * Added a TradeOfferSignature property to GlobalConfig.cs with a default value of null.
   * Modified ArchiWebHandler.cs to retrieve the trade offer signature from ASF.GlobalConfig.TradeOfferSignature.
   * Implemented a fallback mechanism: if TradeOfferSignature is not set in the global config, or if its length exceeds
     MaxTradeOfferMessageLength, the default signature ("Sent by {SharedInfo.PublicIdentifier}/{SharedInfo.Version}") will be used
     instead. This ensures that invalid or excessively long custom signatures do not break trade offer functionality.

  This enhancement improves user customization options without compromising application stability.