### PR TITLE
Support loading logs from non-default files defined in NLog.config

### DIFF
--- a/ArchiSteamFarm/NLog/Logging.cs
+++ b/ArchiSteamFarm/NLog/Logging.cs
@@ -73,7 +73,7 @@ internal static class Logging {
 				.FirstOrDefault();
 
 			if (fileTarget != null) {
-				fileName = fileTarget.FileName.Render(new LogEventInfo { TimeStamp = DateTime.Now });
+				fileName = fileTarget.FileName.Render(new LogEventInfo { TimeStamp = DateTime.MinValue });
 			}
 
 			return field = fileName;


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

None

### Changed functionality

API endpoint loading log-files is now capable of loading non-default files defined in `NLog.config`.

### Removed functionality

None

## Additional info

This is related to JustArchiNET/ASF-ui#1722.

---

Thank you for considering the inclusion of this merge request.
