### PR TITLE
Support Steam URLs in commands as an alternative to app/sub ids

### DIFF
--- a/ArchiSteamFarm.Tests/Utilities.cs
+++ b/ArchiSteamFarm.Tests/Utilities.cs
@@ -1,0 +1,90 @@
+// ----------------------------------------------------------------------------------------------
+//     _                _      _  ____   _                           _____
+//    / \    _ __  ___ | |__  (_)/ ___| | |_  ___   __ _  _ __ ___  |  ___|__ _  _ __  _ __ ___
+//   / _ \  | '__|/ __|| '_ \ | |\___ \ | __|/ _ \ / _` || '_ ` _ \ | |_  / _` || '__|| '_ ` _ \
+//  / ___ \ | |  | (__ | | | || | ___) || |_|  __/| (_| || | | | | ||  _|| (_| || |   | | | | | |
+// /_/   \_\|_|   \___||_| |_||_||____/  \__|\___| \__,_||_| |_| |_||_|   \__,_||_|   |_| |_| |_|
+// ----------------------------------------------------------------------------------------------
+// |
+// Copyright 2015-2026 Łukasz "JustArchi" Domeradzki
+// Contact: JustArchi@JustArchi.net
+// |
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// |
+// http://www.apache.org/licenses/LICENSE-2.0
+// |
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using ArchiSteamFarm.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ArchiSteamFarm.Tests;
+
+#pragma warning disable CA1812 // False positive, the class is used during MSTest
+[TestClass]
+internal sealed class GameIdentifierParser {
+	[DataRow("730", "APP", "APP", 730U)]
+	[DataRow("730", "SUB", "SUB", 730U)]
+	[DataRow("app/730", "SUB", "APP", 730U)]
+	[DataRow("a/730", "SUB", "APP", 730U)]
+	[DataRow("sub/123", "APP", "SUB", 123U)]
+	[DataRow("s/123", "APP", "SUB", 123U)]
+	[DataRow("https://store.steampowered.com/app/730", "SUB", "APP", 730U)]
+	[DataRow("https://store.steampowered.com/sub/123", "APP", "SUB", 123U)]
+	[DataRow("https://store.steampowered.com/app/730/SomeGameName/", "SUB", "APP", 730U)]
+	[TestMethod]
+	internal void TryParseGameIdentifierReturnsExpectedId(string input, string defaultType, string expectedType, uint expectedId) {
+		bool result = Core.Utilities.TryParseGameIdentifier(input, defaultType, out string? type, out uint id);
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(expectedType, type);
+		Assert.AreEqual(expectedId, id);
+	}
+
+	[DataRow("0", "APP")]
+	[DataRow("abc", "APP")]
+	[DataRow("app/0", "SUB")]
+	[DataRow("sub/abc", "APP")]
+	[DataRow("unknown/123", "APP")]
+	[DataRow("https://store.steampowered.com/bundle/123", "APP")]
+	[DataRow("https://example.com/app/730", "APP")]
+	[TestMethod]
+	internal void TryParseGameIdentifierReturnsFalseForInvalidInput(string input, string defaultType) {
+		bool result = Core.Utilities.TryParseGameIdentifier(input, defaultType, out string? type, out uint id);
+
+		Assert.IsFalse(result);
+		Assert.IsNull(type);
+		Assert.AreEqual(0U, id);
+	}
+
+	[DataRow("regex/pattern", "APP", "REGEX", "pattern")]
+	[DataRow("r/test.*", "APP", "REGEX", "test.*")]
+	[DataRow("name/Half-Life", "APP", "NAME", "Half-Life")]
+	[DataRow("n/Portal", "APP", "NAME", "Portal")]
+	[TestMethod]
+	internal void TryParseGameIdentifierStringReturnsExpectedValue(string input, string defaultType, string expectedType, string expectedValue) {
+		bool result = Core.Utilities.TryParseGameIdentifier(input, defaultType, out string? type, out string? value);
+
+		Assert.IsTrue(result);
+		Assert.AreEqual(expectedType, type);
+		Assert.AreEqual(expectedValue, value);
+	}
+
+	[DataRow("regex/pattern", "APP")]
+	[DataRow("name/Half-Life", "APP")]
+	[TestMethod]
+	internal void TryParseGameIdentifierUintReturnsFalseForNonNumericTypes(string input, string defaultType) {
+		bool result = Core.Utilities.TryParseGameIdentifier(input, defaultType, out string? type, out uint id);
+
+		Assert.IsFalse(result);
+		Assert.IsNull(type);
+		Assert.AreEqual(0U, id);
+	}
+}
+#pragma warning restore CA1812 // False positive, the class is used during MSTest

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -254,8 +254,10 @@ public static class Utilities {
 					_ => null
 				};
 
-				if (type != null) {
-					value = uri.Segments[2].TrimEnd('/');
+				string pathValue = uri.Segments[2].TrimEnd('/');
+
+				if ((type != null) && uint.TryParse(pathValue, out uint pathNumericValue) && (pathNumericValue > 0)) {
+					value = pathValue;
 
 					return true;
 				}
@@ -282,6 +284,15 @@ public static class Utilities {
 
 			if (type != null) {
 				value = input[(slashIndex + 1)..];
+
+				if (type is "APP" or "SUB") {
+					if (!uint.TryParse(value, out uint slashNumericValue) || (slashNumericValue == 0)) {
+						type = null;
+						value = null;
+
+						return false;
+					}
+				}
 
 				return true;
 			}

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -37,6 +37,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ArchiSteamFarm.Localization;
 using ArchiSteamFarm.NLog;
+using ArchiSteamFarm.Steam.Integration;
 using ArchiSteamFarm.Storage;
 using Humanizer;
 using JetBrains.Annotations;
@@ -245,21 +246,21 @@ public static class Utilities {
 		ArgumentException.ThrowIfNullOrEmpty(defaultType);
 
 		if (input.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
-			if (Uri.TryCreate(input, UriKind.Absolute, out Uri? uri) && uri.Host.Equals("store.steampowered.com", StringComparison.OrdinalIgnoreCase) && (uri.Segments.Length >= 3)) {
-				string pathType = uri.Segments[1].TrimEnd('/');
+			if (Uri.TryCreate(input, UriKind.Absolute, out Uri? uri) && uri.Host.Equals(ArchiWebHandler.SteamStoreURL.Host, StringComparison.OrdinalIgnoreCase)) {
+				string[] segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
 
-				type = pathType.ToUpperInvariant() switch {
-					"APP" => "APP",
-					"SUB" => "SUB",
-					_ => null
-				};
+				if (segments.Length >= 2) {
+					type = segments[0].ToUpperInvariant() switch {
+						"APP" => "APP",
+						"SUB" => "SUB",
+						_ => null
+					};
 
-				string pathValue = uri.Segments[2].TrimEnd('/');
+					if ((type != null) && uint.TryParse(segments[1], out uint pathNumericValue) && (pathNumericValue > 0)) {
+						value = segments[1];
 
-				if ((type != null) && uint.TryParse(pathValue, out uint pathNumericValue) && (pathNumericValue > 0)) {
-					value = pathValue;
-
-					return true;
+						return true;
+					}
 				}
 			}
 

--- a/ArchiSteamFarm/Core/Utilities.cs
+++ b/ArchiSteamFarm/Core/Utilities.cs
@@ -226,6 +226,85 @@ public static class Utilities {
 		return true;
 	}
 
+	internal static bool TryParseGameIdentifier(string input, string defaultType, [NotNullWhen(true)] out string? type, out uint id) {
+		ArgumentException.ThrowIfNullOrEmpty(input);
+		ArgumentException.ThrowIfNullOrEmpty(defaultType);
+
+		if (TryParseGameIdentifier(input, defaultType, out type, out string? value) && uint.TryParse(value, out id) && (id > 0)) {
+			return true;
+		}
+
+		type = null;
+		id = 0;
+
+		return false;
+	}
+
+	internal static bool TryParseGameIdentifier(string input, string defaultType, [NotNullWhen(true)] out string? type, [NotNullWhen(true)] out string? value) {
+		ArgumentException.ThrowIfNullOrEmpty(input);
+		ArgumentException.ThrowIfNullOrEmpty(defaultType);
+
+		if (input.StartsWith("http", StringComparison.OrdinalIgnoreCase)) {
+			if (Uri.TryCreate(input, UriKind.Absolute, out Uri? uri) && uri.Host.Equals("store.steampowered.com", StringComparison.OrdinalIgnoreCase) && (uri.Segments.Length >= 3)) {
+				string pathType = uri.Segments[1].TrimEnd('/');
+
+				type = pathType.ToUpperInvariant() switch {
+					"APP" => "APP",
+					"SUB" => "SUB",
+					_ => null
+				};
+
+				if (type != null) {
+					value = uri.Segments[2].TrimEnd('/');
+
+					return true;
+				}
+			}
+
+			type = null;
+			value = null;
+
+			return false;
+		}
+
+		int slashIndex = input.IndexOf('/', StringComparison.Ordinal);
+
+		if ((slashIndex > 0) && (input.Length > slashIndex + 1)) {
+			string inputType = input[..slashIndex];
+
+			type = inputType.ToUpperInvariant() switch {
+				"A" or "APP" => "APP",
+				"S" or "SUB" => "SUB",
+				"R" or "REGEX" => "REGEX",
+				"N" or "NAME" => "NAME",
+				_ => null
+			};
+
+			if (type != null) {
+				value = input[(slashIndex + 1)..];
+
+				return true;
+			}
+
+			type = null;
+			value = null;
+
+			return false;
+		}
+
+		if (uint.TryParse(input, out uint numericValue) && (numericValue > 0)) {
+			type = defaultType;
+			value = input;
+
+			return true;
+		}
+
+		type = null;
+		value = null;
+
+		return false;
+	}
+
 	internal static ulong MathAdd(ulong first, int second) {
 		if (second >= 0) {
 			return first + (uint) second;

--- a/ArchiSteamFarm/Steam/Interaction/Commands.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Commands.cs
@@ -659,7 +659,7 @@ public sealed class Commands {
 			}
 
 			switch (type.ToUpperInvariant()) {
-				case "A" or "APP": {
+				case "APP": {
 					HashSet<uint>? packageIDs = ASF.GlobalDatabase?.GetPackageIDs(gameID, Bot.OwnedPackages.Keys, 1);
 
 					if (packageIDs is { Count: > 0 }) {
@@ -684,7 +684,7 @@ public sealed class Commands {
 					break;
 				}
 
-				case "S" or "SUB": {
+				case "SUB": {
 					if (Bot.OwnedPackages.ContainsKey(gameID)) {
 						response.AppendLine(FormatBotResponse(Strings.FormatBotAddLicense($"sub/{gameID}", $"{EResult.Fail}/{EPurchaseResultDetail.AlreadyPurchased}")));
 
@@ -2097,7 +2097,7 @@ public sealed class Commands {
 			}
 
 			switch (type.ToUpperInvariant()) {
-				case "A" or "APP" when uint.TryParse(game, out uint appID) && (appID > 0):
+				case "APP" when uint.TryParse(game, out uint appID) && (appID > 0):
 					HashSet<uint>? packageIDs = ASF.GlobalDatabase?.GetPackageIDs(appID, Bot.OwnedPackages.Keys, 1);
 
 					if (packageIDs?.Count > 0) {
@@ -2128,7 +2128,7 @@ public sealed class Commands {
 					}
 
 					break;
-				case "R" or "REGEX":
+				case "REGEX":
 					Regex regex;
 
 					try {
@@ -2171,7 +2171,7 @@ public sealed class Commands {
 					}
 
 					continue;
-				case "S" or "SUB" when uint.TryParse(game, out uint packageID) && (packageID > 0):
+				case "SUB" when uint.TryParse(game, out uint packageID) && (packageID > 0):
 					if (Bot.OwnedPackages.ContainsKey(packageID)) {
 						result[$"sub/{packageID}"] = packageID.ToString(CultureInfo.InvariantCulture);
 						response.AppendLine(FormatBotResponse(Strings.FormatBotOwnedAlready($"sub/{packageID}")));
@@ -3006,7 +3006,7 @@ public sealed class Commands {
 			}
 
 			switch (type.ToUpperInvariant()) {
-				case "A" or "APP": {
+				case "APP": {
 					HashSet<uint>? packageIDs = ASF.GlobalDatabase?.GetPackageIDs(gameID, Bot.OwnedPackages.Keys, 1);
 
 					if (packageIDs is { Count: 0 }) {
@@ -3022,7 +3022,7 @@ public sealed class Commands {
 					break;
 				}
 
-				case "S" or "SUB": {
+				case "SUB": {
 					if (!Bot.OwnedPackages.ContainsKey(gameID)) {
 						response.AppendLine(FormatBotResponse(Strings.FormatBotAddLicense($"sub/{gameID}", EResult.InvalidState)));
 

--- a/ArchiSteamFarm/Steam/Interaction/Commands.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Commands.cs
@@ -652,22 +652,7 @@ public sealed class Commands {
 		string[] entries = query.Split(SharedInfo.ListElementSeparators, StringSplitOptions.RemoveEmptyEntries);
 
 		foreach (string entry in entries) {
-			uint gameID;
-			string type;
-
-			int index = entry.IndexOf('/', StringComparison.Ordinal);
-
-			if ((index > 0) && (entry.Length > index + 1)) {
-				if (!uint.TryParse(entry[(index + 1)..], out gameID) || (gameID == 0)) {
-					response.AppendLine(FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(gameID))));
-
-					continue;
-				}
-
-				type = entry[..index];
-			} else if (uint.TryParse(entry, out gameID) && (gameID > 0)) {
-				type = "SUB";
-			} else {
+			if (!Utilities.TryParseGameIdentifier(entry, "SUB", out string? type, out uint gameID)) {
 				response.AppendLine(FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(gameID))));
 
 				continue;
@@ -1336,7 +1321,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1405,7 +1390,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -1495,7 +1480,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1571,7 +1556,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -1861,7 +1846,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 
@@ -1942,7 +1927,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1999,7 +1984,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!uint.TryParse(target, out uint appID) || (appID == 0)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -2103,14 +2088,9 @@ public sealed class Commands {
 			string game;
 			string type;
 
-			int index = entry.IndexOf('/', StringComparison.Ordinal);
-
-			if ((index > 0) && (entry.Length > index + 1)) {
-				game = entry[(index + 1)..];
-				type = entry[..index];
-			} else if (uint.TryParse(entry, out uint appID) && (appID > 0)) {
-				game = entry;
-				type = "APP";
+			if (Utilities.TryParseGameIdentifier(entry, "APP", out string? parsedType, out string? parsedValue)) {
+				game = parsedValue;
+				type = parsedType;
 			} else {
 				game = entry;
 				type = "NAME";
@@ -2365,7 +2345,7 @@ public sealed class Commands {
 		StringBuilder gameName = new();
 
 		foreach (string game in games) {
-			if (!uint.TryParse(game, out uint gameID) || (gameID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(game, "APP", out string? type, out uint gameID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				if (gameName.Length > 0) {
 					gameName.Append(' ');
 				}
@@ -3019,22 +2999,7 @@ public sealed class Commands {
 		string[] entries = query.Split(SharedInfo.ListElementSeparators, StringSplitOptions.RemoveEmptyEntries);
 
 		foreach (string entry in entries) {
-			uint gameID;
-			string type;
-
-			int index = entry.IndexOf('/', StringComparison.Ordinal);
-
-			if ((index > 0) && (entry.Length > index + 1)) {
-				if (!uint.TryParse(entry[(index + 1)..], out gameID) || (gameID == 0)) {
-					response.AppendLine(FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(gameID))));
-
-					continue;
-				}
-
-				type = entry[..index];
-			} else if (uint.TryParse(entry, out gameID) && (gameID > 0)) {
-				type = "SUB";
-			} else {
+			if (!Utilities.TryParseGameIdentifier(entry, "SUB", out string? type, out uint gameID)) {
 				response.AppendLine(FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(gameID))));
 
 				continue;
@@ -3603,7 +3568,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 
@@ -3637,7 +3602,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!uint.TryParse(appIDText, out uint appID) || (appID == 0)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
 				return FormatStaticResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 

--- a/ArchiSteamFarm/Steam/Interaction/Commands.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Commands.cs
@@ -1321,7 +1321,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1390,7 +1390,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -1480,7 +1480,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1556,7 +1556,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -1846,7 +1846,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 
@@ -1927,7 +1927,7 @@ public sealed class Commands {
 		HashSet<uint> appIDs = [];
 
 		foreach (string target in targets) {
-			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 			}
 
@@ -1984,7 +1984,7 @@ public sealed class Commands {
 
 					break;
 				default:
-					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+					if (!Utilities.TryParseGameIdentifier(target, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 						return FormatBotResponse(Strings.FormatErrorParsingObject(nameof(appID)));
 					}
 
@@ -2345,7 +2345,7 @@ public sealed class Commands {
 		StringBuilder gameName = new();
 
 		foreach (string game in games) {
-			if (!Utilities.TryParseGameIdentifier(game, "APP", out string? type, out uint gameID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(game, "APP", out string? type, out uint gameID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				if (gameName.Length > 0) {
 					gameName.Append(' ');
 				}
@@ -3568,7 +3568,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatBotResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 
@@ -3602,7 +3602,7 @@ public sealed class Commands {
 		HashSet<uint> realAppIDs = [];
 
 		foreach (string appIDText in appIDTexts) {
-			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.OrdinalIgnoreCase)) {
+			if (!Utilities.TryParseGameIdentifier(appIDText, "APP", out string? type, out uint appID) || !type.Equals("APP", StringComparison.Ordinal)) {
 				return FormatStaticResponse(Strings.FormatErrorIsInvalid(nameof(appID)));
 			}
 


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Added support for Steam URLs in commands which expect app id or sub id, examples:

```
!owns https://store.steampowered.com/app/570/Dota_2/
!play https://store.steampowered.com/app/570/Dota_2/
```

## Additional info

Additionally this PR normalizes parsing of the input across all 12 commands.

<img width="1078" height="544" alt="image" src="https://github.com/user-attachments/assets/bd914d17-5f85-465e-b16d-f157b8dae2f9" />
<img width="1065" height="600" alt="image" src="https://github.com/user-attachments/assets/5d1ee444-d805-48ca-b3c9-44e9b32dd72b" />
