### PR TITLE
CI: add generic flavor docker images

### DIFF
--- a/.github/workflows/docker-publish-generic.yml
+++ b/.github/workflows/docker-publish-generic.yml
@@ -1,4 +1,4 @@
-name: ASF-docker-publish-latest
+name: ASF-docker-publish-generic
 
 on:
   release:
@@ -64,7 +64,7 @@ jobs:
           type=match,pattern=^(\d+)\.\d+\.\d+\.\d+$,group=1
           type=raw,value=${{ env.TAG }}
         flavor: |
-          latest=off
+          latest=false
 
     - name: Build and publish Docker image from Dockerfile
       uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0

--- a/.github/workflows/docker-publish-generic.yml
+++ b/.github/workflows/docker-publish-generic.yml
@@ -1,0 +1,81 @@
+name: ASF-docker-publish-latest
+
+on:
+  release:
+    types: [released]
+
+env:
+  PLATFORMS: linux/amd64,linux/arm,linux/arm64
+  TAG: generic
+
+permissions:
+  packages: write
+
+jobs:
+  main:
+    environment: release-docker
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        show-progress: false
+        submodules: recursive
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+    - name: Login to ghcr.io
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Login to DockerHub
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Prepare environment outputs
+      shell: sh
+      run: |
+        set -eu
+
+        echo "GHCR_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+        echo "DH_REPOSITORY=$(echo ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
+
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+      with:
+        # Only push releases to Docker Hub
+        images: |
+          ghcr.io/${{ env.GHCR_REPOSITORY }}
+          ${{ env.DH_REPOSITORY }}
+        tags: |
+          # Matches 1.2.3.4 and outputs 1.2.3
+          type=match,pattern=^(\d+\.\d+\.\d+)\.\d+$,group=1
+          # Matches 1.2.3.4 and outputs 1.2
+          type=match,pattern=^(\d+\.\d+)\.\d+\.\d+$,group=1
+          # Matches 1.2.3.4 and outputs 1
+          type=match,pattern=^(\d+)\.\d+\.\d+\.\d+$,group=1
+          type=raw,value=${{ env.TAG }}
+        flavor: |
+          latest=off
+
+    - name: Build and publish Docker image from Dockerfile
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+      with:
+        context: .
+        platforms: ${{ env.PLATFORMS }}
+        provenance: true
+        sbom: true
+        secrets: |
+          ASF_PRIVATE_SNK=${{ secrets.ASF_PRIVATE_SNK }}
+          STEAM_TOKEN_DUMPER_TOKEN=${{ secrets.STEAM_TOKEN_DUMPER_TOKEN }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        push: true


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [X] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [X] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [X] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [X] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] <del>I have added tests to cover my changes, wherever they are necessary.</del>
- [ ] <del>All new and existing tests pass.</del>

## Changes

### New functionality

Added 4 new Docker tag series:
- `A.B.C`, `A.B`, `A` - tracks the latest released patch/minor/major version, i.e., ignoring pre-releases. This is useful for partial version pinning. It also uses the generic flavor, in line with the flavor of `A.B.C.D` tags.
- `generic` - this is a generic version of `latest` (and a stable version of `released`).

### Changed functionality

<!-- Please describe below, what old functionality was changed. -->

### Removed functionality

<!-- Please describe below, what old functionality was removed. Make sure to mention what it was replaced with or how everything that was previously achievable still is. -->

## Additional info

Why this is useful: The service flavor `latest` images are built with trimming enabled, making it hard to work with plugins that require a full .NET Framework. While the `A.B.C.D` images are not, they are pinned and require manual update. A major version / `generic` tag allows external tools to handle updates while also having better plugin compatibility.