### PR TITLE
Implement steam launch URL handling

### DIFF
--- a/ArchiSteamFarm.Tests/SteamUtilities.cs
+++ b/ArchiSteamFarm.Tests/SteamUtilities.cs
@@ -39,6 +39,8 @@ internal sealed class SteamUtilities {
 	[DataRow("https://store.steampowered.com/app/730", EGameIdentifier.Package, EGameIdentifier.Application, 730U)]
 	[DataRow("https://store.steampowered.com/sub/123", EGameIdentifier.Application, EGameIdentifier.Package, 123U)]
 	[DataRow("https://store.steampowered.com/app/730/SomeGameName/", EGameIdentifier.Package, EGameIdentifier.Application, 730U)]
+	[DataRow("steam://launch/730/Dialog", EGameIdentifier.Package, EGameIdentifier.Application, 730U)]
+	[DataRow("steam://launch/730/", EGameIdentifier.Package, EGameIdentifier.Application, 730U)]
 	[TestMethod]
 	internal void TryParseGameIdentifierReturnsExpectedId(string input, EGameIdentifier defaultType, EGameIdentifier expectedType, uint expectedId) {
 		bool result = TryParseGameIdentifier(input, defaultType, out EGameIdentifier? type, out uint id);

--- a/ArchiSteamFarm/Steam/Integration/SteamUtilities.cs
+++ b/ArchiSteamFarm/Steam/Integration/SteamUtilities.cs
@@ -171,6 +171,19 @@ public static class SteamUtilities {
 			}
 		}
 
+		// Handle steam://launch/APPID/ and steam://launch/APPID/Dialog formats
+		if (input.StartsWith("steam://launch/", StringComparison.OrdinalIgnoreCase)) {
+			string launchPath = input["steam://launch/".Length..];
+			string[] launchSegments = launchPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+			if ((launchSegments.Length >= 1) && uint.TryParse(launchSegments[0], out uint launchAppId) && (launchAppId > 0)) {
+				type = EGameIdentifier.Application;
+				value = launchSegments[0];
+
+				return true;
+			}
+		}
+
 		int slashIndex = input.IndexOf('/', StringComparison.Ordinal);
 
 		if ((slashIndex > 0) && (input.Length > slashIndex + 1)) {


### PR DESCRIPTION
Add handling for steam://launch/APPID/ formats in SteamUtilities.

## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [X] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [X] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [X] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [X] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [X] I have added tests to cover my changes, wherever they are necessary.
- [X] All new and existing tests pass.

## Changes

### New functionality

On Steam pages, you have the "Play Now" buttons. This generates URLs such as
steam://launch/123123123/Dialog
This parses those urls.